### PR TITLE
[PR]: parse read .cub file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,9 @@ LDFLAGS		= -lm -lXext -lX11
 SRCS		= $(SRC_DIR)/main.c \
 			  $(SRC_DIR)/events/close.c \
 			  $(SRC_DIR)/init/framebuffer.c \
-			  $(SRC_DIR)/render/render.c
+			  $(SRC_DIR)/render/render.c \
+			  $(SRC_DIR)/parsing/file.c \
+			  $(SRC_DIR)/parsing/utils.c
 OBJS		= ${SRCS:${SRC_DIR}/%.c=${OBJ_DIR}/%.o}
 
 all: ${NAME}

--- a/include/parsing.h
+++ b/include/parsing.h
@@ -1,35 +1,30 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   cub3d.h                                            :+:      :+:    :+:   */
+/*   parsing.h                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: dajesus- <dajesus-@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2026/02/25 21:05:13 by dajesus-          #+#    #+#             */
-/*   Updated: 2026/02/27 21:54:57 by dajesus-         ###   ########.fr       */
+/*   Created: 2026/02/27 20:49:50 by dajesus-          #+#    #+#             */
+/*   Updated: 2026/02/27 21:55:26 by dajesus-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#ifndef CUB3D_H
-# define CUB3D_H
-
-# include <stdlib.h>
-# include <unistd.h>
-# include <fcntl.h>
-
-# include "../lib/libft/libft.h"
-# include "../lib/minilibx-linux/mlx.h"
+#ifndef PARSING_H
+# define PARSING_H
 
 # include "structs.h"
-# include "events.h"
-# include "parsing.h"
 
-# define CUB3D_WIN_TITLE "cub3D"
-# define CUB3D_WIN_W 800
-# define CUB3D_WIN_H 600
+typedef struct s_file
+{
+	char	*path;
+	char	**lines;
+	int		line_count;
+}			t_file;
 
-int		framebuffer_init(t_app *app);
-void	framebuffer_destroy(t_app *app);
-int		render_frame(t_app *app);
+int		ft_print_error(const char *msg);
+int		ft_has_cub_extension(const char *path);
+int		parse_cub_file(int argc, char **argv, t_file *file);
+void	free_file(t_file *file);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: dajesus- <dajesus-@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/25 21:02:28 by dajesus-          #+#    #+#             */
-/*   Updated: 2026/02/26 21:14:03 by dajesus-         ###   ########.fr       */
+/*   Updated: 2026/02/27 21:55:01 by dajesus-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,14 +43,23 @@ static int	app_init(t_app *app)
 	return (1);
 }
 
+static int	check_errors(int argc, char **argv, t_file *file)
+{
+	if (parse_cub_file(argc, argv, file) != 0)
+		return (1);
+	return (0);
+}
+
 int	main(int argc, char **argv)
 {
 	t_app	app;
+	t_file	file;
 
-	(void)argv;
-	(void)argc;
+	if (check_errors(argc, argv, &file) != 0)
+		return (1);
 	if (!app_init(&app))
 	{
+		free_file(&file);
 		app_destroy(&app);
 		return (1);
 	}
@@ -58,6 +67,7 @@ int	main(int argc, char **argv)
 	mlx_hook(app.mlx.win, 17, 0, on_destroy, &app);
 	mlx_loop_hook(app.mlx.ptr, render_frame, &app);
 	mlx_loop(app.mlx.ptr);
+	free_file(&file);
 	app_destroy(&app);
 	return (0);
 }

--- a/src/parsing/file.c
+++ b/src/parsing/file.c
@@ -1,0 +1,101 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   file.c                                             :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dajesus- <dajesus-@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/02/27 20:49:50 by dajesus-          #+#    #+#             */
+/*   Updated: 2026/02/27 21:55:06 by dajesus-         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../include/cub3d.h"
+
+static char	**append_line(char **old, int count, char *line)
+{
+	char	**tmp;
+	int		i;
+
+	tmp = ft_calloc(count + 2, sizeof(char *));
+	if (!tmp)
+		return (NULL);
+	i = 0;
+	while (i < count)
+	{
+		tmp[i] = old[i];
+		i++;
+	}
+	tmp[count] = line;
+	free(old);
+	return (tmp);
+}
+
+static int	read_all_lines(int fd, t_file *file)
+{
+	char	*line;
+
+	file->lines = NULL;
+	file->line_count = 0;
+	while (1)
+	{
+		line = get_next_line(fd);
+		if (!line)
+			break ;
+		file->lines = append_line(file->lines, file->line_count, line);
+		if (!file->lines)
+		{
+			free(line);
+			return (0);
+		}
+		file->line_count++;
+	}
+	return (1);
+}
+
+static int	load_file(const char *path, t_file *file)
+{
+	int	fd;
+
+	file->path = (char *)path;
+	file->lines = NULL;
+	file->line_count = 0;
+	fd = open(path, O_RDONLY);
+	if (fd < 0)
+		return (ft_print_error("cannot open map file"));
+	if (!read_all_lines(fd, file))
+	{
+		close(fd);
+		return (ft_print_error("failed to read map file"));
+	}
+	close(fd);
+	return (0);
+}
+
+void	free_file(t_file *file)
+{
+	int	i;
+
+	if (!file || !file->lines)
+		return ;
+	i = 0;
+	while (i < file->line_count)
+	{
+		free(file->lines[i]);
+		i++;
+	}
+	free(file->lines);
+	file->lines = NULL;
+	file->line_count = 0;
+}
+
+int	parse_cub_file(int argc, char **argv, t_file *file)
+{
+	if (argc != 2)
+		return (ft_print_error("usage: ./cub3D map.cub"));
+	if (!ft_has_cub_extension(argv[1]))
+		return (ft_print_error("invalid map extension (expected .cub)"));
+	if (load_file(argv[1], file) != 0)
+		return (1);
+	return (0);
+}

--- a/src/parsing/utils.c
+++ b/src/parsing/utils.c
@@ -1,0 +1,36 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   utils.c                                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dajesus- <dajesus-@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/02/27 21:15:15 by dajesus-          #+#    #+#             */
+/*   Updated: 2026/02/27 21:55:22 by dajesus-         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../include/cub3d.h"
+
+int	ft_print_error(const char *msg)
+{
+	write(2, "Error\n", 6);
+	if (msg)
+	{
+		write(2, msg, ft_strlen(msg));
+		write(2, "\n", 1);
+	}
+	return (1);
+}
+
+int	ft_has_cub_extension(const char *path)
+{
+	size_t	len;
+
+	if (!path)
+		return (0);
+	len = ft_strlen(path);
+	if (len < 4)
+		return (0);
+	return (ft_strncmp(path + (len - 4), ".cub", 4) == 0);
+}

--- a/src/render/render.c
+++ b/src/render/render.c
@@ -6,18 +6,28 @@
 /*   By: dajesus- <dajesus-@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/26 20:42:34 by dajesus-          #+#    #+#             */
-/*   Updated: 2026/02/26 21:13:50 by dajesus-         ###   ########.fr       */
+/*   Updated: 2026/02/27 21:55:16 by dajesus-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../include/cub3d.h"
 
+static void	clear_row(char *row, int w, int bytes)
+{
+	int	x;
+
+	x = 0;
+	while (x < w)
+	{
+		ft_bzero(row + (x * bytes), bytes);
+		x++;
+	}
+}
+
 static void	clear_frame(t_img *img)
 {
 	int		bytes;
 	int		y;
-	int		x;
-	char	*row;
 
 	if (!img || !img->addr)
 		return ;
@@ -27,13 +37,7 @@ static void	clear_frame(t_img *img)
 	y = 0;
 	while (y < img->h)
 	{
-		row = img->addr + (y * img->line_len);
-		x = 0;
-		while (x < img->w)
-		{
-			ft_bzero(row + (x * bytes), bytes);
-			x++;
-		}
+		clear_row(img->addr + (y * img->line_len), img->w, bytes);
 		y++;
 	}
 }


### PR DESCRIPTION
Add argc validation (exactly 2 arguments)
Add error on extra or missing arguments
Add .cub extension validation
Add open/read file
Add store raw lines

No memory leak. Tested with:
```bash
valgrind --leak-check=full --show-leak-kinds=all ./cub3D maps/ok.cub
```
No norminette errors

Issue: #7 