### PR TITLE
Fix memory leak and validation

### DIFF
--- a/src/parsing/file.c
+++ b/src/parsing/file.c
@@ -34,6 +34,7 @@ static char	**append_line(char **old, int count, char *line)
 static int	read_all_lines(int fd, t_file *file)
 {
 	char	*line;
+	char	**new_lines;
 
 	file->lines = NULL;
 	file->line_count = 0;
@@ -42,12 +43,14 @@ static int	read_all_lines(int fd, t_file *file)
 		line = get_next_line(fd);
 		if (!line)
 			break ;
-		file->lines = append_line(file->lines, file->line_count, line);
-		if (!file->lines)
+		new_lines = append_line(file->lines, file->line_count, line);
+		if (!new_lines)
 		{
 			free(line);
+			free_file(file);
 			return (0);
 		}
+		file->lines = new_lines;
 		file->line_count++;
 	}
 	return (1);

--- a/src/parsing/textures.c
+++ b/src/parsing/textures.c
@@ -82,5 +82,7 @@ int	parse_textures(t_app *app, t_file *file)
 			return (1);
 		i++;
 	}
+	if (!app->tex.no || !app->tex.so || !app->tex.we || !app->tex.ea)
+		return (ft_print_error("missing texture identifier(s)"));
 	return (0);
 }


### PR DESCRIPTION
### 1. `append_line` leaks the previous array on allocation failure

File: `src/parsing/file.c:15–32` 

When `ft_calloc` fails inside `append_line`, `old` (the previous array) is not freed.
The caller (`read_all_lines`) then frees `line` but cannot free `old` because it no
longer has a reference to it. All previously-read lines are leaked.

```c
tmp = ft_calloc(count + 2, sizeof(char *));
if (!tmp)
    return (NULL);    // old is not freed here
```

### 2. `parse_textures` does not validate that all four textures were found

File: `src/parsing/textures.c:71–85` 

After iterating all lines, there is no check that all four entries in `t_tex_paths` are
non-NULL. A map file missing one or more texture declarations will silently succeed,
leaving NULL pointers in the struct.

This is confirmed by the presence of `maps/invalid/textures_missing.cub`, but there is
no corresponding validation in `parse_textures`.