### PR TITLE
[PR]: parse: floor and ceiling colors (F, C)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,9 @@ TEST_SRCS	= $(TEST_DIR)/unit/parsing/test_parsing_unit.c \
 			  $(TEST_DIR)/integration/parsing/test_parsing_integration.c \
 			  $(SRC_DIR)/parsing/file.c \
 			  $(SRC_DIR)/parsing/utils.c \
-			  $(SRC_DIR)/parsing/textures.c
+			  $(SRC_DIR)/parsing/textures.c \
+			  $(SRC_DIR)/parsing/colors.c \
+			  $(SRC_DIR)/parsing/colors_utils.c
 TEST_OBJS	= ${TEST_SRCS:%.c=${OBJ_DIR}/%.test.o}
 
 # Coverage flags (tests only)

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ CRIT_INC	= -I $(CRIT_DIR)/include
 CRIT_LIBDIR	= $(CRIT_DIR)/lib
 CRIT_LIBS	= -L $(CRIT_LIBDIR) -lcriterion
 
-INCLUDE		= -I include -I ${LIBFT_DIR} -I ${MLX_DIR} $(CRIT_INC)
+INCLUDE		= -I include -I ${LIBFT_DIR} -I ${MLX_DIR}
 LDFLAGS		= -lm -lXext -lX11
 
 SRCS		= $(SRC_DIR)/main.c \
@@ -28,7 +28,9 @@ SRCS		= $(SRC_DIR)/main.c \
 			  $(SRC_DIR)/render/render.c \
 			  $(SRC_DIR)/parsing/file.c \
 			  $(SRC_DIR)/parsing/utils.c \
-			  $(SRC_DIR)/parsing/textures.c
+			  $(SRC_DIR)/parsing/textures.c \
+			  $(SRC_DIR)/parsing/colors.c \
+			  $(SRC_DIR)/parsing/colors_utils.c
 OBJS		= ${SRCS:${SRC_DIR}/%.c=${OBJ_DIR}/%.o}
 
 TEST_NAME	= tests_bin

--- a/include/parsing.h
+++ b/include/parsing.h
@@ -6,7 +6,7 @@
 /*   By: dajesus- <dajesus-@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/27 20:49:50 by dajesus-          #+#    #+#             */
-/*   Updated: 2026/02/28 02:01:04 by dajesus-         ###   ########.fr       */
+/*   Updated: 2026/03/01 14:21:31 by dajesus-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,5 +30,8 @@ void	free_file(t_file *file);
 
 int		parse_textures(t_app *app, t_file *file);
 void	free_textures(t_tex_paths *tex);
+int		parse_colors(t_app *app, t_file *file);
+void	free_split(char **parts);
+int		is_valid_component(char *s);
 
 #endif

--- a/include/structs.h
+++ b/include/structs.h
@@ -6,7 +6,7 @@
 /*   By: dajesus- <dajesus-@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/25 21:12:23 by dajesus-          #+#    #+#             */
-/*   Updated: 2026/02/28 01:21:55 by dajesus-         ###   ########.fr       */
+/*   Updated: 2026/03/01 14:21:31 by dajesus-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,12 +38,21 @@ typedef struct s_tex_paths
 	char	*ea;
 }			t_tex_paths;
 
+typedef struct s_rgb
+{
+	int		r;
+	int		g;
+	int		b;
+}			t_rgb;
+
 typedef struct s_app
 {
 	t_mlx			mlx;
 	int				running;
 	t_img			frame;
 	t_tex_paths		tex;
+	t_rgb			floor;
+	t_rgb			ceiling;
 }					t_app;
 
 #endif

--- a/lib/libft/Makefile
+++ b/lib/libft/Makefile
@@ -7,8 +7,8 @@ PRINTF_DIR = ./ft_printf
 PRINTF_LIB = $(PRINTF_DIR)/libftprintf.a
 
 SRCS = \
-	ft_bzero.c ft_isalnum.c ft_isalpha.c ft_isascii.c \
-	ft_isdigit.c ft_isprint.c ft_memchr.c ft_memcmp.c \
+	ft_bzero.c ft_isalnum.c ft_isalpha.c ft_isascii.c ft_isspace.c \
+	ft_isdigit.c ft_isprint.c ft_memchr.c ft_memcmp.c ft_skip_spaces.c \
 	ft_memcpy.c ft_memmove.c ft_memset.c ft_strchr.c \
 	ft_strlen.c ft_strncmp.c ft_strcmp.c ft_strrchr.c ft_toupper.c \
 	ft_tolower.c ft_strlcpy.c ft_strlcat.c ft_strnstr.c \

--- a/lib/libft/ft_isspace.c
+++ b/lib/libft/ft_isspace.c
@@ -1,38 +1,19 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   ft_atoi.c                                          :+:      :+:    :+:   */
+/*   ft_isspace.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: dajesus- <dajesus-@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2024/10/16 15:03:43 by dajesus-          #+#    #+#             */
-/*   Updated: 2024/10/25 17:47:09 by dajesus-         ###   ########.fr       */
+/*   Created: 2024/10/09 11:58:53 by dajesus-          #+#    #+#             */
+/*   Updated: 2025/08/19 21:56:10 by dajesus-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
-int	ft_atoi(const char *nptr)
+int	ft_isspace(int c)
 {
-	int		i;
-	int		sign;
-	int		result;
-
-	i = 0;
-	sign = 1;
-	result = 0;
-	while (ft_isspace(nptr[i]))
-		i++;
-	if (nptr[i] == '-' || nptr[i] == '+')
-	{
-		if (nptr[i] == '-')
-			sign = -1;
-		i++;
-	}
-	while (nptr[i] >= '0' && nptr[i] <= '9')
-	{
-		result = result * 10 + (nptr[i] - '0');
-		i++;
-	}
-	return (result * sign);
+	return (c == ' ' || c == '\t' || c == '\n'
+		|| c == '\v' || c == '\f' || c == '\r');
 }

--- a/lib/libft/ft_skip_spaces.c
+++ b/lib/libft/ft_skip_spaces.c
@@ -1,38 +1,20 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   ft_atoi.c                                          :+:      :+:    :+:   */
+/*   ft_skip_spaces.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: dajesus- <dajesus-@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2024/10/16 15:03:43 by dajesus-          #+#    #+#             */
-/*   Updated: 2024/10/25 17:47:09 by dajesus-         ###   ########.fr       */
+/*   Created: 2026/03/01 14:17:50 by dajesus-          #+#    #+#             */
+/*   Updated: 2026/03/01 14:21:31 by dajesus-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
-int	ft_atoi(const char *nptr)
+char	*ft_skip_spaces(char *s)
 {
-	int		i;
-	int		sign;
-	int		result;
-
-	i = 0;
-	sign = 1;
-	result = 0;
-	while (ft_isspace(nptr[i]))
-		i++;
-	if (nptr[i] == '-' || nptr[i] == '+')
-	{
-		if (nptr[i] == '-')
-			sign = -1;
-		i++;
-	}
-	while (nptr[i] >= '0' && nptr[i] <= '9')
-	{
-		result = result * 10 + (nptr[i] - '0');
-		i++;
-	}
-	return (result * sign);
+	while (*s && ft_isspace((unsigned char)*s))
+		s++;
+	return (s);
 }

--- a/lib/libft/libft.h
+++ b/lib/libft/libft.h
@@ -6,7 +6,7 @@
 /*   By: dajesus- <dajesus-@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/10 09:27:56 by dajesus-          #+#    #+#             */
-/*   Updated: 2025/02/12 10:07:18 by dajesus-         ###   ########.fr       */
+/*   Updated: 2026/03/01 14:21:31 by dajesus-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,6 +32,7 @@ int		ft_isalpha(int c);
 int		ft_isalnum(int c);
 int		ft_isdigit(int c);
 int		ft_isascii(int c);
+int		ft_isspace(int c);
 int		ft_tolower(int c);
 int		ft_toupper(int c);
 int		ft_isprint(int c);
@@ -67,6 +68,7 @@ t_list	*ft_lstnew(void *content);
 t_list	*ft_lstmap(t_list *lst, void *(*f)(void *), void (*del)(void *));
 char	*ft_itoa(int n);
 char	*get_next_line(int fd);
+char	*ft_skip_spaces(char *s);
 char	*ft_strdup(const char *s);
 char	*ft_strchr(const char *s, int c);
 char	*ft_strrchr(const char *s, int c);

--- a/maps/invalid/color_invalid_rgb.cub
+++ b/maps/invalid/color_invalid_rgb.cub
@@ -1,0 +1,21 @@
+NO ./assets/textures/north.xpm
+SO ./assets/textures/south.xpm
+WE ./assets/textures/west.xpm
+EA ./assets/textures/east.xpm
+
+F 20,20,-20
+C 200,200,200
+
+11111
+10001
+10S01
+10001
+10001
+10001
+11001
+10001
+10001
+10001
+10001
+10001
+11111

--- a/maps/invalid/color_missing.cub
+++ b/maps/invalid/color_missing.cub
@@ -1,0 +1,20 @@
+NO ./assets/textures/north.xpm
+SO ./assets/textures/south.xpm
+WE ./assets/textures/west.xpm
+EA ./assets/textures/east.xpm
+
+F 200,200,200
+
+11111
+10001
+10S01
+10001
+10001
+10001
+11001
+10001
+10001
+10001
+10001
+10001
+11111

--- a/maps/invalid/color_missing_ceiling_rgb.cub
+++ b/maps/invalid/color_missing_ceiling_rgb.cub
@@ -1,0 +1,21 @@
+NO ./assets/textures/north.xpm
+SO ./assets/textures/south.xpm
+WE ./assets/textures/west.xpm
+EA ./assets/textures/east.xpm
+
+F 20,20,20
+C 200,200,
+
+11111
+10001
+10S01
+10001
+10001
+10001
+11001
+10001
+10001
+10001
+10001
+10001
+11111

--- a/maps/invalid/color_missing_floor_rgb.cub
+++ b/maps/invalid/color_missing_floor_rgb.cub
@@ -1,0 +1,21 @@
+NO ./assets/textures/north.xpm
+SO ./assets/textures/south.xpm
+WE ./assets/textures/west.xpm
+EA ./assets/textures/east.xpm
+
+F 20,20
+C 200,200,200
+
+11111
+10001
+10S01
+10001
+10001
+10001
+11001
+10001
+10001
+10001
+10001
+10001
+11111

--- a/maps/invalid/color_none.cub
+++ b/maps/invalid/color_none.cub
@@ -1,0 +1,18 @@
+NO ./assets/textures/north.xpm
+SO ./assets/textures/south.xpm
+WE ./assets/textures/west.xpm
+EA ./assets/textures/east.xpm
+
+11111
+10001
+10S01
+10001
+10001
+10001
+11001
+10001
+10001
+10001
+10001
+10001
+11111

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: dajesus- <dajesus-@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/25 21:02:28 by dajesus-          #+#    #+#             */
-/*   Updated: 2026/02/28 01:21:56 by dajesus-         ###   ########.fr       */
+/*   Updated: 2026/03/01 14:21:31 by dajesus-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,6 +51,12 @@ static int	check_errors(int argc, char **argv, t_file *file)
 	if (parse_cub_file(argc, argv, file) != 0)
 		return (1);
 	if (parse_textures(&tmp, file) != 0)
+	{
+		free_textures(&tmp.tex);
+		free_file(file);
+		return (1);
+	}
+	if (parse_colors(&tmp, file) != 0)
 	{
 		free_textures(&tmp.tex);
 		free_file(file);

--- a/src/parsing/colors.c
+++ b/src/parsing/colors.c
@@ -1,0 +1,96 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   colors.c                                           :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dajesus- <dajesus-@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/03/01 01:40:51 by dajesus-          #+#    #+#             */
+/*   Updated: 2026/03/01 14:21:50 by dajesus-         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../include/cub3d.h"
+
+static int	parse_component(char *s, int *out)
+{
+	if (!is_valid_component(s))
+		return (0);
+	*out = ft_atoi(ft_skip_spaces(s));
+	return (*out >= 0 && *out <= 255);
+}
+
+static int	parse_rgb(t_rgb *dst, char *value_str)
+{
+	char	**p;
+	int		r;
+	int		g;
+	int		b;
+
+	p = ft_split(value_str, ',');
+	if (!p)
+		return (ft_print_error("malloc failed"));
+	if (!p[0] || !p[1] || !p[2] || p[3])
+	{
+		free_split(p);
+		return (ft_print_error("invalid RGB format"));
+	}
+	if (!parse_component(p[0], &r) || !parse_component(p[1], &g)
+		|| !parse_component(p[2], &b))
+	{
+		free_split(p);
+		return (ft_print_error("invalid RGB value"));
+	}
+	dst->r = r;
+	dst->g = g;
+	dst->b = b;
+	free_split(p);
+	return (0);
+}
+
+static int	set_color(t_rgb *dst, int *seen, char *value_str)
+{
+	if (*seen)
+		return (ft_print_error("duplicate color identifier"));
+	*seen = 1;
+	return (parse_rgb(dst, value_str));
+}
+
+static int	handle_color_line(t_app *app, char *line, int *seen_f, int *seen_c)
+{
+	char	id;
+
+	line = ft_skip_spaces(line);
+	if (*line == '\0')
+		return (0);
+	id = *line;
+	line++;
+	line = ft_skip_spaces(line);
+	if (id == 'F')
+		return (set_color(&app->floor, seen_f, line));
+	if (id == 'C')
+		return (set_color(&app->ceiling, seen_c, line));
+	return (0);
+}
+
+int	parse_colors(t_app *app, t_file *file)
+{
+	int	seen_f;
+	int	seen_c;
+	int	i;
+	int	err;
+
+	if (!app || !file)
+		return (ft_print_error("internal error"));
+	seen_f = 0;
+	seen_c = 0;
+	i = 0;
+	while (i < file->line_count)
+	{
+		err = handle_color_line(app, file->lines[i], &seen_f, &seen_c);
+		if (err != 0)
+			return (1);
+		i++;
+	}
+	return (0);
+}

--- a/src/parsing/colors.c
+++ b/src/parsing/colors.c
@@ -6,7 +6,7 @@
 /*   By: dajesus- <dajesus-@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/03/01 01:40:51 by dajesus-          #+#    #+#             */
-/*   Updated: 2026/03/01 14:21:50 by dajesus-         ###   ########.fr       */
+/*   Updated: 2026/03/01 15:09:02 by dajesus-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -92,5 +92,7 @@ int	parse_colors(t_app *app, t_file *file)
 			return (1);
 		i++;
 	}
+	if (!seen_f || !seen_c)
+		return (ft_print_error("missing color identifier"));
 	return (0);
 }

--- a/src/parsing/colors_utils.c
+++ b/src/parsing/colors_utils.c
@@ -1,0 +1,39 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   colors_utils.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dajesus- <dajesus-@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/03/01 14:39:33 by dajesus-          #+#    #+#             */
+/*   Updated: 2026/03/01 14:40:07 by dajesus-         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../include/cub3d.h"
+
+void	free_split(char **parts)
+{
+	int	i;
+
+	if (!parts)
+		return ;
+	i = 0;
+	while (parts[i])
+	{
+		free(parts[i]);
+		i++;
+	}
+	free(parts);
+}
+
+int	is_valid_component(char *s)
+{
+	s = ft_skip_spaces(s);
+	if (*s == '\0')
+		return (0);
+	while (ft_isdigit(*s))
+		s++;
+	s = ft_skip_spaces(s);
+	return (*s == '\0');
+}

--- a/tests/integration/parsing/test_parsing_integration.c
+++ b/tests/integration/parsing/test_parsing_integration.c
@@ -65,3 +65,81 @@ Test(parse_textures, rejects_non_xpm_texture_path)
 	cr_assert(parse_textures(&app, &file) != 0);
 	free_all(&file, &app);
 }
+
+Test(parse_colors, accepts_valid_colors)
+{
+	t_file	file;
+	t_app	app;
+
+	ft_bzero(&app, sizeof(app));
+	cr_assert(parse_cub_file(2, (char *[]) {"./cub3D",
+		"tests/fixtures/valid/simple.cub", NULL}, &file) == 0);
+	cr_assert(parse_textures(&app, &file) == 0);
+	cr_assert(parse_colors(&app, &file) == 0);
+	free_all(&file, &app);
+}
+
+Test(parse_colors, rejects_when_colors_missing_both)
+{
+	t_file	file;
+	t_app	app;
+
+	ft_bzero(&app, sizeof(app));
+	cr_assert(parse_cub_file(2, (char *[]) {"./cub3D",
+		"maps/invalid/color_none.cub", NULL}, &file) == 0);
+	cr_assert(parse_textures(&app, &file) == 0);
+	cr_assert(parse_colors(&app, &file) != 0);
+	free_all(&file, &app);
+}
+
+Test(parse_colors, rejects_when_one_identifier_missing)
+{
+	t_file	file;
+	t_app	app;
+
+	ft_bzero(&app, sizeof(app));
+	cr_assert(parse_cub_file(2, (char *[]) {"./cub3D",
+		"maps/invalid/color_missing.cub", NULL}, &file) == 0);
+	cr_assert(parse_textures(&app, &file) == 0);
+	cr_assert(parse_colors(&app, &file) != 0);
+	free_all(&file, &app);
+}
+
+Test(parse_colors, rejects_missing_floor_rgb_component)
+{
+	t_file	file;
+	t_app	app;
+
+	ft_bzero(&app, sizeof(app));
+	cr_assert(parse_cub_file(2, (char *[]) {"./cub3D",
+		"maps/invalid/color_missing_floor_rgb.cub", NULL}, &file) == 0);
+	cr_assert(parse_textures(&app, &file) == 0);
+	cr_assert(parse_colors(&app, &file) != 0);
+	free_all(&file, &app);
+}
+
+Test(parse_colors, rejects_missing_ceiling_rgb_component)
+{
+	t_file	file;
+	t_app	app;
+
+	ft_bzero(&app, sizeof(app));
+	cr_assert(parse_cub_file(2, (char *[]) {"./cub3D",
+		"maps/invalid/color_missing_ceiling_rgb.cub", NULL}, &file) == 0);
+	cr_assert(parse_textures(&app, &file) == 0);
+	cr_assert(parse_colors(&app, &file) != 0);
+	free_all(&file, &app);
+}
+
+Test(parse_colors, rejects_invalid_rgb_value)
+{
+	t_file	file;
+	t_app	app;
+
+	ft_bzero(&app, sizeof(app));
+	cr_assert(parse_cub_file(2, (char *[]) {"./cub3D",
+		"maps/invalid/color_invalid_rgb.cub", NULL}, &file) == 0);
+	cr_assert(parse_textures(&app, &file) == 0);
+	cr_assert(parse_colors(&app, &file) != 0);
+	free_all(&file, &app);
+}


### PR DESCRIPTION
Add parse RGB values
Add range check (0–255)
Add detect duplicates

No memory leak. Tested with:
```bash
valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --track-fds=all ./cub3D maps/valid/simple.cub
```
Tested with invalid maps:
empty.cub
color_none.cub
color_missing.cub
color_missing_floor_rgb.cub
color_missing_ceiling_rgb.cub
color_invalid_rgb.cub

No norminette errors

Issue: #9 