### PR TITLE
[PR]: Player init from spawn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ SRCS		= $(SRC_DIR)/main.c \
 			  $(SRC_DIR)/events/close.c \
 			  $(SRC_DIR)/init/framebuffer.c \
 			  $(SRC_DIR)/render/render.c \
+			  $(SRC_DIR)/player/player_init.c \
 			  $(SRC_DIR)/parsing/file.c \
 			  $(SRC_DIR)/parsing/utils.c \
 			  $(SRC_DIR)/parsing/textures.c \

--- a/include/player.h
+++ b/include/player.h
@@ -1,36 +1,20 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   cub3d.h                                            :+:      :+:    :+:   */
+/*   player.h                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: dajesus- <dajesus-@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2026/02/25 21:05:13 by dajesus-          #+#    #+#             */
-/*   Updated: 2026/03/03 18:13:18 by dajesus-         ###   ########.fr       */
+/*   Created: 2026/03/03 17:10:00 by dajesus-          #+#    #+#             */
+/*   Updated: 2026/03/03 18:13:07 by dajesus-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#ifndef CUB3D_H
-# define CUB3D_H
-
-# include <stdlib.h>
-# include <unistd.h>
-# include <fcntl.h>
-
-# include "../lib/libft/libft.h"
-# include "../lib/minilibx-linux/mlx.h"
+#ifndef PLAYER_H
+# define PLAYER_H
 
 # include "structs.h"
-# include "events.h"
-# include "parsing.h"
-# include "player.h"
 
-# define CUB3D_WIN_TITLE "cub3D"
-# define CUB3D_WIN_W 800
-# define CUB3D_WIN_H 600
-
-int		framebuffer_init(t_app *app);
-void	framebuffer_destroy(t_app *app);
-int		render_frame(t_app *app);
+int	player_init(t_app *app);
 
 #endif

--- a/include/structs.h
+++ b/include/structs.h
@@ -6,7 +6,7 @@
 /*   By: dajesus- <dajesus-@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/25 21:12:23 by dajesus-          #+#    #+#             */
-/*   Updated: 2026/03/03 16:56:02 by dajesus-         ###   ########.fr       */
+/*   Updated: 2026/03/03 18:13:01 by dajesus-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,6 +55,14 @@ typedef struct s_file
 	int		map_width;
 }			t_file;
 
+typedef struct s_player
+{
+	double	x;
+	double	y;
+	double	dir_x;
+	double	dir_y;
+}			t_player;
+
 typedef struct s_app
 {
 	t_mlx			mlx;
@@ -66,6 +74,7 @@ typedef struct s_app
 	int				spawn_x;
 	int				spawn_y;
 	char			spawn_dir;
+	t_player		player;
 }					t_app;
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: dajesus- <dajesus-@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/25 21:02:28 by dajesus-          #+#    #+#             */
-/*   Updated: 2026/03/03 16:56:14 by dajesus-         ###   ########.fr       */
+/*   Updated: 2026/03/03 18:12:48 by dajesus-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,7 +29,6 @@ static void	app_destroy(t_app *app)
 
 static int	app_init(t_app *app)
 {
-	ft_bzero(app, sizeof(*app));
 	app->running = 1;
 	app->mlx.ptr = mlx_init();
 	if (!app->mlx.ptr)
@@ -55,23 +54,22 @@ static int	parse_all(t_app *tmp, t_file *file)
 		return (1);
 	if (validate_player_spawn(tmp, file) != 0)
 		return (1);
+	if (player_init(tmp) != 0)
+		return (1);
 	return (0);
 }
 
-static int	check_errors(int argc, char **argv, t_file *file)
+static int	parse_setup(t_app *app, t_file *file, int argc, char **argv)
 {
-	t_app	tmp;
-
-	ft_bzero(&tmp, sizeof(tmp));
+	ft_bzero(app, sizeof(*app));
 	if (parse_cub_file(argc, argv, file) != 0)
 		return (1);
-	if (parse_all(&tmp, file) != 0)
+	if (parse_all(app, file) != 0)
 	{
-		free_textures(&tmp.tex);
+		free_textures(&app->tex);
 		free_file(file);
 		return (1);
 	}
-	free_textures(&tmp.tex);
 	return (0);
 }
 
@@ -80,10 +78,11 @@ int	main(int argc, char **argv)
 	t_app	app;
 	t_file	file;
 
-	if (check_errors(argc, argv, &file) != 0)
+	if (parse_setup(&app, &file, argc, argv) != 0)
 		return (1);
 	if (!app_init(&app))
 	{
+		free_textures(&app.tex);
 		free_file(&file);
 		app_destroy(&app);
 		return (1);
@@ -92,6 +91,7 @@ int	main(int argc, char **argv)
 	mlx_hook(app.mlx.win, 17, 0, on_destroy, &app);
 	mlx_loop_hook(app.mlx.ptr, render_frame, &app);
 	mlx_loop(app.mlx.ptr);
+	free_textures(&app.tex);
 	free_file(&file);
 	app_destroy(&app);
 	return (0);

--- a/src/player/player_init.c
+++ b/src/player/player_init.c
@@ -1,0 +1,41 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   player_init.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dajesus- <dajesus-@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/03/03 17:40:33 by dajesus-          #+#    #+#             */
+/*   Updated: 2026/03/03 18:21:07 by dajesus-         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../include/cub3d.h"
+
+static void	set_dir(t_player *player, char spawn_dir)
+{
+	player->dir_x = 0.0;
+	player->dir_y = 0.0;
+	if (spawn_dir == 'N')
+		player->dir_y = -1.0;
+	else if (spawn_dir == 'S')
+		player->dir_y = 1.0;
+	else if (spawn_dir == 'E')
+		player->dir_x = 1.0;
+	else if (spawn_dir == 'W')
+		player->dir_x = -1.0;
+}
+
+int	player_init(t_app *app)
+{
+	if (!app)
+		return (ft_print_error("internal error"));
+	if (app->spawn_x < 0 || app->spawn_y < 0)
+		return (ft_print_error("invalid player spawn"));
+	app->player.x = (double)app->spawn_x + 0.5;
+	app->player.y = (double)app->spawn_y + 0.5;
+	set_dir(&app->player, app->spawn_dir);
+	if (app->player.dir_x == 0.0 && app->player.dir_y == 0.0)
+		return (ft_print_error("invalid player direction"));
+	return (0);
+}


### PR DESCRIPTION
Add initialize position and direction

No memory leak. Tested with:
```bash
valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --track-fds=all ./cub3D maps/valid/simple.cub
```

No norminette errors

Issue: #23 