### PR TITLE
fix: reject unknown lines before map block and gaps inside map

### DIFF
--- a/maps/invalid/empty_line_in_map.cub
+++ b/maps/invalid/empty_line_in_map.cub
@@ -1,0 +1,14 @@
+NO ./assets/textures/north.xpm
+SO ./assets/textures/south.xpm
+WE ./assets/textures/west.xpm
+EA ./assets/textures/east.xpm
+
+F 220,100,0
+C 225,30,0
+
+111111
+100101
+
+101001
+1100N1
+111111

--- a/maps/invalid/junk_before_map.cub
+++ b/maps/invalid/junk_before_map.cub
@@ -1,0 +1,15 @@
+NO ./assets/textures/north.xpm
+SO ./assets/textures/south.xpm
+WE ./assets/textures/west.xpm
+EA ./assets/textures/east.xpm
+
+F 220,100,0
+C 225,30,0
+
+JUNK
+
+111111
+100101
+101001
+1100N1
+111111

--- a/src/parsing/map_parse.c
+++ b/src/parsing/map_parse.c
@@ -12,13 +12,61 @@
 
 #include "../../include/cub3d.h"
 
+static int	is_directive_line(char *line)
+{
+	char	*s;
+
+	s = ft_skip_spaces(line);
+	if (*s == '\0' || *s == '\n')
+		return (1);
+	if ((*s == 'F' || *s == 'C')
+		&& (s[1] == ' ' || s[1] == '\t' || s[1] == '\n' || s[1] == '\0'))
+		return (1);
+	if (ft_strncmp(s, "NO", 2) == 0 && (s[2] == ' ' || s[2] == '\t'))
+		return (1);
+	if (ft_strncmp(s, "SO", 2) == 0 && (s[2] == ' ' || s[2] == '\t'))
+		return (1);
+	if (ft_strncmp(s, "WE", 2) == 0 && (s[2] == ' ' || s[2] == '\t'))
+		return (1);
+	if (ft_strncmp(s, "EA", 2) == 0 && (s[2] == ' ' || s[2] == '\t'))
+		return (1);
+	return (0);
+}
+
+static int	validate_pre_map(t_file *file, int map_start)
+{
+	int	i;
+
+	i = 0;
+	while (i < map_start)
+	{
+		if (!is_directive_line(file->lines[i]))
+			return (ft_print_error("invalid line in file"));
+		i++;
+	}
+	return (0);
+}
+
+static int	validate_post_map(t_file *file, int map_end)
+{
+	int		i;
+	char	*trimmed;
+
+	i = map_end + 1;
+	while (i < file->line_count)
+	{
+		trimmed = ft_skip_spaces(file->lines[i]);
+		if (*trimmed != '\0' && *trimmed != '\n')
+			return (ft_print_error("invalid map character"));
+		i++;
+	}
+	return (0);
+}
+
 int	parse_map(t_app *app, t_file *file)
 {
 	int		start;
 	int		end;
-	int		i;
-	char	*line;
-	char	*trimmed;
 
 	(void)app;
 	if (!file || !file->lines)
@@ -27,15 +75,10 @@ int	parse_map(t_app *app, t_file *file)
 		return (ft_print_error("missing map"));
 	if (!validate_map_range(file, start, end))
 		return (ft_print_error("invalid map character"));
-	i = end + 1;
-	while (i < file->line_count)
-	{
-		line = file->lines[i];
-		trimmed = ft_skip_spaces(line);
-		if (*trimmed != '\0' && *trimmed != '\n')
-			return (ft_print_error("invalid map character"));
-		i++;
-	}
+	if (validate_pre_map(file, start) != 0)
+		return (1);
+	if (validate_post_map(file, end) != 0)
+		return (1);
 	if (dup_map_block(file, start, end) != 0)
 		return (1);
 	return (0);


### PR DESCRIPTION
`find_map_range()` selects the **last consecutive block** of map-like lines by scanning backward from the end of the file. It only validates:
- Characters within that selected block
- That lines **after** the block are blank

Nothing validates the lines **before** the block. Both `parse_textures()` and `parse_colors()` silently skip any line they do not recognise, so an unknown non-empty line placed anywhere in the header is never caught.

## What it caused

- **Unknown lines silently accepted**: a line like `JUNK` between the texture/color directives and the map was accepted without error, violating the subject requirement that `.cub` files must contain only recognised content.
- **Empty line gap inside the map**: an empty line in the middle of the intended map caused `find_map_range()` to stop its upward scan early, keeping only the lower portion as the map. The orphaned lines above the gap were not part of the selected block and were never validated.

## How to reproduce

**Bug 1 – unknown header line:**
```
NO ./assets/textures/north.xpm
SO ./assets/textures/south.xpm
WE ./assets/textures/west.xpm
EA ./assets/textures/east.xpm

F 220,100,0
C 225,30,0

JUNK

111111
100101
101001
1100N1
111111
```
Run `./cub3D <file>` — before this fix the file was accepted; it should be rejected.

**Bug 2 – empty line gap in map:**
```
111111
100101

101001
1100N1
111111
```
The empty line splits the map. Before this fix, only the lower 4 lines were used as the map without any error.

## Changes

**`src/parsing/map_parse.c`**

- Added `is_directive_line()` — classifies a line as a known/allowed header line (blank, or starts with `NO`/`SO`/`WE`/`EA`/`F`/`C`).
- Added `validate_pre_map()` — iterates every line before the selected map block and rejects anything that is not a known directive, catching both unknown lines and orphaned map lines that were split off by a gap.
- Added `validate_post_map()` — extracted the existing post-map blank-line check from `parse_map()` into its own function, keeping `parse_map()` under the 25-line norminette limit.
- `parse_map()` now calls all three validators in sequence before duplicating the map block.

**`maps/invalid/junk_before_map.cub`** — new test map for bug 1.

**`maps/invalid/empty_line_in_map.cub`** — new test map for bug 2.

## Testing

All 4 existing valid maps continue to launch correctly. All 31 existing invalid maps continue to fail with their expected errors. Both new invalid maps are now correctly rejected with `"invalid line in file"`.