### PR TITLE
fix: require whitespace after F/C color identifier

### DIFF
--- a/maps/invalid/color_bare_identifier.cub
+++ b/maps/invalid/color_bare_identifier.cub
@@ -1,0 +1,13 @@
+NO ./assets/textures/north.xpm
+SO ./assets/textures/south.xpm
+WE ./assets/textures/west.xpm
+EA ./assets/textures/east.xpm
+
+F
+C 225,30,0
+
+111111
+100101
+101001
+1100N1
+111111

--- a/maps/invalid/color_no_space.cub
+++ b/maps/invalid/color_no_space.cub
@@ -1,0 +1,13 @@
+NO ./assets/textures/north.xpm
+SO ./assets/textures/south.xpm
+WE ./assets/textures/west.xpm
+EA ./assets/textures/east.xpm
+
+FLOOR 220,100,0
+C 225,30,0
+
+111111
+100101
+101001
+1100N1
+111111

--- a/maps/invalid/color_no_space.cub
+++ b/maps/invalid/color_no_space.cub
@@ -3,8 +3,8 @@ SO ./assets/textures/south.xpm
 WE ./assets/textures/west.xpm
 EA ./assets/textures/east.xpm
 
-FLOOR 220,100,0
-C 225,30,0
+F220,100,0
+C225,30,0
 
 111111
 100101

--- a/src/parsing/colors.c
+++ b/src/parsing/colors.c
@@ -64,13 +64,15 @@ static int	handle_color_line(t_app *app, char *line, int *seen_f, int *seen_c)
 	if (*line == '\0')
 		return (0);
 	id = *line;
+	if (id != 'F' && id != 'C')
+		return (0);
+	if (line[1] != ' ' && line[1] != '\t')
+		return (0);
 	line++;
 	line = ft_skip_spaces(line);
 	if (id == 'F')
 		return (set_color(&app->floor, seen_f, line));
-	if (id == 'C')
-		return (set_color(&app->ceiling, seen_c, line));
-	return (0);
+	return (set_color(&app->ceiling, seen_c, line));
 }
 
 int	parse_colors(t_app *app, t_file *file)

--- a/src/parsing/colors.c
+++ b/src/parsing/colors.c
@@ -66,10 +66,13 @@ static int	handle_color_line(t_app *app, char *line, int *seen_f, int *seen_c)
 	id = *line;
 	if (id != 'F' && id != 'C')
 		return (0);
-	if (line[1] != ' ' && line[1] != '\t')
+	if (line[1] != ' ' && line[1] != '\t'
+		&& line[1] != '\0' && line[1] != '\n')
 		return (0);
 	line++;
 	line = ft_skip_spaces(line);
+	if (*line == '\0' || *line == '\n')
+		return (ft_print_error("invalid RGB format"));
 	if (id == 'F')
 		return (set_color(&app->floor, seen_f, line));
 	return (set_color(&app->ceiling, seen_c, line));

--- a/tests/integration/parsing/test_parsing_integration.c
+++ b/tests/integration/parsing/test_parsing_integration.c
@@ -157,6 +157,19 @@ Test(parse_colors, rejects_identifier_without_space)
 	free_all(&file, &app);
 }
 
+Test(parse_colors, rejects_bare_identifier_line)
+{
+	t_file	file;
+	t_app	app;
+
+	ft_bzero(&app, sizeof(app));
+	cr_assert(parse_cub_file(2, (char *[]) {"./cub3D",
+		"maps/invalid/color_bare_identifier.cub", NULL}, &file) == 0);
+	cr_assert(parse_textures(&app, &file) == 0);
+	cr_assert(parse_colors(&app, &file) != 0);
+	free_all(&file, &app);
+}
+
 Test(parse_map, accepts_map_only_file)
 {
 	t_file	file;

--- a/tests/integration/parsing/test_parsing_integration.c
+++ b/tests/integration/parsing/test_parsing_integration.c
@@ -144,6 +144,19 @@ Test(parse_colors, rejects_invalid_rgb_value)
 	free_all(&file, &app);
 }
 
+Test(parse_colors, rejects_identifier_without_space)
+{
+	t_file	file;
+	t_app	app;
+
+	ft_bzero(&app, sizeof(app));
+	cr_assert(parse_cub_file(2, (char *[]) {"./cub3D",
+		"maps/invalid/color_no_space.cub", NULL}, &file) == 0);
+	cr_assert(parse_textures(&app, &file) == 0);
+	cr_assert(parse_colors(&app, &file) != 0);
+	free_all(&file, &app);
+}
+
 Test(parse_map, accepts_map_only_file)
 {
 	t_file	file;


### PR DESCRIPTION
## Summary

- `handle_color_line()` only checked the first character of a line, treating any line starting with `F` or `C` as a color directive (e.g. `FLOOR 220,100,0` would be parsed as a color line, producing a misleading "invalid RGB" error)
- Added a guard requiring a space or tab after `F`/`C`, consistent with `match_id()` in `textures.c` and `is_directive_line()` in `map_parse.c`
- Added test fixture (`maps/invalid/color_no_space.cub`) and integration test for regression coverage

Fixes #35