### PR TITLE
[PR]: render vertical wall slices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ SRCS		= $(SRC_DIR)/main.c \
 			  $(SRC_DIR)/events/input.c \
 			  $(SRC_DIR)/init/framebuffer.c \
 			  $(SRC_DIR)/render/render.c \
+			  $(SRC_DIR)/render/wall_slices.c \
 			  $(SRC_DIR)/raycasting/raycast_core.c \
 			  $(SRC_DIR)/raycasting/raycast_init.c \
 			  $(SRC_DIR)/raycasting/raycast_dda.c \

--- a/include/cub3d.h
+++ b/include/cub3d.h
@@ -6,7 +6,7 @@
 /*   By: dajesus- <dajesus-@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/25 21:05:13 by dajesus-          #+#    #+#             */
-/*   Updated: 2026/03/06 22:49:46 by dajesus-         ###   ########.fr       */
+/*   Updated: 2026/03/08 21:55:08 by dajesus-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,5 +37,6 @@
 int		framebuffer_init(t_app *app);
 void	framebuffer_destroy(t_app *app);
 int		render_frame(t_app *app);
+void	render_walls(t_app *app);
 
 #endif

--- a/include/structs.h
+++ b/include/structs.h
@@ -6,7 +6,7 @@
 /*   By: dajesus- <dajesus-@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/25 21:12:23 by dajesus-          #+#    #+#             */
-/*   Updated: 2026/03/08 01:30:07 by dajesus-         ###   ########.fr       */
+/*   Updated: 2026/03/08 21:55:18 by dajesus-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -98,6 +98,14 @@ typedef struct s_ray
 	int		hit;
 	int		side;
 }			t_ray;
+
+typedef struct s_draw
+{
+	int				x;
+	int				start;
+	int				end;
+	unsigned int	color;
+}					t_draw;
 
 typedef struct s_app
 {

--- a/src/render/render.c
+++ b/src/render/render.c
@@ -6,7 +6,7 @@
 /*   By: dajesus- <dajesus-@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/26 20:42:34 by dajesus-          #+#    #+#             */
-/*   Updated: 2026/02/27 21:55:16 by dajesus-         ###   ########.fr       */
+/*   Updated: 2026/03/08 21:55:41 by dajesus-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,6 +50,7 @@ int	render_frame(t_app *app)
 		return (0);
 	player_update(app);
 	clear_frame(&app->frame);
+	render_walls(app);
 	mlx_put_image_to_window(app->mlx.ptr, app->mlx.win, app->frame.ptr, 0, 0);
 	return (0);
 }

--- a/src/render/wall_slices.c
+++ b/src/render/wall_slices.c
@@ -1,0 +1,105 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   wall_slices.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dajesus- <dajesus-@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/03/08 02:08:09 by dajesus-          #+#    #+#             */
+/*   Updated: 2026/03/08 21:54:37 by dajesus-         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "cub3d.h"
+
+static unsigned int	wall_color(int side)
+{
+	if (side == 1)
+		return (0x00777777);
+	return (0x00BBBBBB);
+}
+
+static double	ray_wall_t(t_ray *ray)
+{
+	if (!ray)
+		return (RAY_HUGE);
+	if (ray->side == 0)
+		return (ray->side_dist_x - ray->delta_dist_x);
+	return (ray->side_dist_y - ray->delta_dist_y);
+}
+
+static double	ray_player_to_wall_dist(t_ray *ray)
+{
+	double		t;
+	double		len;
+
+	t = ray_wall_t(ray);
+	if (t >= RAY_HUGE)
+		return (RAY_HUGE);
+	len = sqrt(ray->dir_x * ray->dir_x + ray->dir_y * ray->dir_y);
+	return (fabs(t) * len);
+}
+
+static void	draw_vline(t_img *img, t_draw *draw)
+{
+	char	*dst;
+	int		bytes;
+	int		y;
+	int		y_end;
+
+	if (!img || !img->addr || img->bpp <= 0 || !draw)
+		return ;
+	bytes = img->bpp / 8;
+	if (draw->x < 0 || draw->x >= img->w || bytes <= 0)
+		return ;
+	y = draw->start;
+	y_end = draw->end;
+	if (y < 0)
+		y = 0;
+	if (y_end >= img->h)
+		y_end = img->h - 1;
+	while (y <= y_end)
+	{
+		dst = img->addr + (y * img->line_len) + (draw->x * bytes);
+		ft_memcpy(dst, &draw->color, bytes);
+		y++;
+	}
+}
+
+static void	render_column(t_app *app, t_img *img, int x)
+{
+	t_ray		ray;
+	t_draw		draw;
+	double		dist;
+	int			line_h;
+
+	ray_init(app, x, &ray);
+	ray_dda(app, &ray);
+	dist = ray_player_to_wall_dist(&ray);
+	if (dist < 0.0001)
+		dist = 0.0001;
+	line_h = (int)((double)img->h / dist);
+	draw.x = x;
+	draw.start = (-line_h / 2) + (img->h / 2);
+	draw.end = (line_h / 2) + (img->h / 2);
+	draw.color = wall_color(ray.side);
+	draw_vline(img, &draw);
+}
+
+void	render_walls(t_app *app)
+{
+	t_img	*img;
+	int		x;
+
+	if (!app || !app->file)
+		return ;
+	img = &app->frame;
+	if (!img || !img->addr || img->w <= 0 || img->h <= 0)
+		return ;
+	x = 0;
+	while (x < img->w)
+	{
+		render_column(app, img, x);
+		x++;
+	}
+}

--- a/src/render/wall_slices.c
+++ b/src/render/wall_slices.c
@@ -6,7 +6,7 @@
 /*   By: dajesus- <dajesus-@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/03/08 02:08:09 by dajesus-          #+#    #+#             */
-/*   Updated: 2026/03/08 21:54:37 by dajesus-         ###   ########.fr       */
+/*   Updated: 2026/03/09 01:07:05 by dajesus-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,25 +19,21 @@ static unsigned int	wall_color(int side)
 	return (0x00BBBBBB);
 }
 
-static double	ray_wall_t(t_ray *ray)
+static double	ray_perp_dist(t_app *app, t_ray *ray)
 {
-	if (!ray)
+	if (!app || !ray)
 		return (RAY_HUGE);
 	if (ray->side == 0)
-		return (ray->side_dist_x - ray->delta_dist_x);
-	return (ray->side_dist_y - ray->delta_dist_y);
-}
-
-static double	ray_player_to_wall_dist(t_ray *ray)
-{
-	double		t;
-	double		len;
-
-	t = ray_wall_t(ray);
-	if (t >= RAY_HUGE)
+	{
+		if (ray->dir_x == 0.0)
+			return (RAY_HUGE);
+		return (((double)ray->map_x - app->player.x
+				+ (1.0 - (double)ray->step_x) / 2.0) / ray->dir_x);
+	}
+	if (ray->dir_y == 0.0)
 		return (RAY_HUGE);
-	len = sqrt(ray->dir_x * ray->dir_x + ray->dir_y * ray->dir_y);
-	return (fabs(t) * len);
+	return (((double)ray->map_y - app->player.y
+			+ (1.0 - (double)ray->step_y) / 2.0) / ray->dir_y);
 }
 
 static void	draw_vline(t_img *img, t_draw *draw)
@@ -75,7 +71,7 @@ static void	render_column(t_app *app, t_img *img, int x)
 
 	ray_init(app, x, &ray);
 	ray_dda(app, &ray);
-	dist = ray_player_to_wall_dist(&ray);
+	dist = ray_perp_dist(app, &ray);
 	if (dist < 0.0001)
 		dist = 0.0001;
 	line_h = (int)((double)img->h / dist);


### PR DESCRIPTION
Add render walls by perpendicular distance

No memory leak. Tested with:
```bash
valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --track-fds=all ./cub3D maps/valid/simple.cub
```

No norminette errors

Issue: #28 