### PR TITLE
Feat/issue 45

### DIFF
--- a/src/render/render.c
+++ b/src/render/render.c
@@ -6,7 +6,7 @@
 /*   By: vinda-si <vinda-si@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/26 20:42:34 by dajesus-          #+#    #+#             */
-/*   Updated: 2026/03/09 22:35:57 by vinda-si         ###   ########.fr       */
+/*   Updated: 2026/03/09 22:50:11 by vinda-si         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,7 +17,6 @@ static unsigned int	rgb_to_int(t_rgb color)
 	return ((color.r << 16) | (color.g << 8) | color.b);
 }
 
-
 static void	fill_background_half(t_img *img, int start, int end, unsigned int c)
 {
 	int		x;
@@ -26,7 +25,7 @@ static void	fill_background_half(t_img *img, int start, int end, unsigned int c)
 	char	*dst;
 
 	bytes = img->bpp / 8;
-	if (bytes <=0)
+	if (bytes <= 0)
 		return ;
 	y = start;
 	while (y < end)
@@ -46,7 +45,8 @@ static void	draw_background(t_app *app)
 {
 	unsigned int	c_color;
 	unsigned int	f_color;
-	if (!app | !app->frame.addr)
+
+	if (!app || !app->frame.addr)
 		return ;
 	c_color = rgb_to_int(app->ceiling);
 	f_color = rgb_to_int(app->floor);
@@ -61,7 +61,7 @@ int	render_frame(t_app *app)
 	if (!app->mlx.win || !app->frame.ptr)
 		return (0);
 	player_update(app);
-	clear_frame(&app->frame);
+	draw_background(app);
 	render_walls(app);
 	mlx_put_image_to_window(app->mlx.ptr, app->mlx.win, app->frame.ptr, 0, 0);
 	return (0);

--- a/src/render/render.c
+++ b/src/render/render.c
@@ -3,43 +3,55 @@
 /*                                                        :::      ::::::::   */
 /*   render.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dajesus- <dajesus-@student.42.fr>          +#+  +:+       +#+        */
+/*   By: vinda-si <vinda-si@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/26 20:42:34 by dajesus-          #+#    #+#             */
-/*   Updated: 2026/03/08 21:55:41 by dajesus-         ###   ########.fr       */
+/*   Updated: 2026/03/09 22:35:57 by vinda-si         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "cub3d.h"
 
-static void	clear_row(char *row, int w, int bytes)
+static unsigned int	rgb_to_int(t_rgb color)
 {
-	int	x;
+	return ((color.r << 16) | (color.g << 8) | color.b);
+}
 
-	x = 0;
-	while (x < w)
+
+static void	fill_background_half(t_img *img, int start, int end, unsigned int c)
+{
+	int		x;
+	int		y;
+	int		bytes;
+	char	*dst;
+
+	bytes = img->bpp / 8;
+	if (bytes <=0)
+		return ;
+	y = start;
+	while (y < end)
 	{
-		ft_bzero(row + (x * bytes), bytes);
-		x++;
+		x = 0;
+		while (x < img->w)
+		{
+			dst = img->addr + (y * img->line_len) + (x * bytes);
+			ft_memcpy(dst, &c, bytes);
+			x++;
+		}
+		y++;
 	}
 }
 
-static void	clear_frame(t_img *img)
+static void	draw_background(t_app *app)
 {
-	int		bytes;
-	int		y;
-
-	if (!img || !img->addr)
+	unsigned int	c_color;
+	unsigned int	f_color;
+	if (!app | !app->frame.addr)
 		return ;
-	bytes = img->bpp / 8;
-	if (bytes <= 0)
-		return ;
-	y = 0;
-	while (y < img->h)
-	{
-		clear_row(img->addr + (y * img->line_len), img->w, bytes);
-		y++;
-	}
+	c_color = rgb_to_int(app->ceiling);
+	f_color = rgb_to_int(app->floor);
+	fill_background_half(&app->frame, 0, app->frame.h / 2, c_color);
+	fill_background_half(&app->frame, app->frame.h / 2, app->frame.h, f_color);
 }
 
 int	render_frame(t_app *app)


### PR DESCRIPTION
Implementa a renderização das cores separadas para o teto e para o chão, conforme pede o pdf. Aproveitando a alteração, para otimizar o processo de limpeza da tela a cada frame.

O que fiz:

- Conversão de cor: Criei a função rgb_to_int para converter cores (R, G, B) para hexadecimal.
- Fundo da tela: O background agora é dividido ao meio. A metade de cima é preenchida com a cor do teto e a de baixo com a do chão, logo antes de desenhar as paredes.
- Otimização de performance: Removi as funções clear_frame e clear_row. Ao invés vez de limpar a tela pixel por pixel usando ft_bzero, agora usamos ft_memcpy para preencher blocos inteiros de memória.