### PR TITLE
Feat/issue 46

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ SRCS		= $(SRC_DIR)/main.c \
 			  $(SRC_DIR)/events/close.c \
 			  $(SRC_DIR)/events/input.c \
 			  $(SRC_DIR)/init/framebuffer.c \
+			  $(SRC_DIR)/init/textures_load.c \
 			  $(SRC_DIR)/render/render.c \
 			  $(SRC_DIR)/render/wall_slices.c \
 			  $(SRC_DIR)/raycasting/raycast_core.c \

--- a/include/cub3d.h
+++ b/include/cub3d.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   cub3d.h                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dajesus- <dajesus-@student.42.fr>          +#+  +:+       +#+        */
+/*   By: vinda-si <vinda-si@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/25 21:05:13 by dajesus-          #+#    #+#             */
-/*   Updated: 2026/03/08 21:55:08 by dajesus-         ###   ########.fr       */
+/*   Updated: 2026/03/11 23:21:33 by vinda-si         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,5 +38,7 @@ int		framebuffer_init(t_app *app);
 void	framebuffer_destroy(t_app *app);
 int		render_frame(t_app *app);
 void	render_walls(t_app *app);
+int		init_loaded_textures(t_app *app);
+void	free_loaded_textures(t_app *app);
 
 #endif

--- a/include/structs.h
+++ b/include/structs.h
@@ -13,6 +13,8 @@
 #ifndef STRUCTS_H
 # define STRUCTS_H
 
+# define NUM_WALL_TEX 4
+
 typedef struct s_img
 {
 	void	*ptr;
@@ -107,12 +109,20 @@ typedef struct s_draw
 	unsigned int	color;
 }					t_draw;
 
+typedef enum e_wall_dir
+{
+	TEX_NO,
+	TEX_SO,
+	TEX_WE,
+	TEX_EA
+}			t_wall_dir;
+
 typedef struct s_app
 {
 	t_mlx			mlx;
 	int				running;
 	t_img			frame;
-	t_img			wall_text[4];
+	t_img			wall_text[NUM_WALL_TEX];
 	t_tex_paths		tex;
 	t_rgb			floor;
 	t_rgb			ceiling;

--- a/include/structs.h
+++ b/include/structs.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   structs.h                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dajesus- <dajesus-@student.42.fr>          +#+  +:+       +#+        */
+/*   By: vinda-si <vinda-si@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/25 21:12:23 by dajesus-          #+#    #+#             */
-/*   Updated: 2026/03/08 21:55:18 by dajesus-         ###   ########.fr       */
+/*   Updated: 2026/03/11 22:58:06 by vinda-si         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -112,6 +112,7 @@ typedef struct s_app
 	t_mlx			mlx;
 	int				running;
 	t_img			frame;
+	t_img			wall_text[4];
 	t_tex_paths		tex;
 	t_rgb			floor;
 	t_rgb			ceiling;

--- a/src/events/close.c
+++ b/src/events/close.c
@@ -31,7 +31,7 @@ void	free_loaded_textures(t_app *app)
 	if (!app || !app->mlx.ptr)
 		return ;
 	i = 0;
-	while (i < 4)
+	while (i < NUM_WALL_TEX)
 	{
 		if (app->wall_text[i].ptr)
 		{

--- a/src/events/close.c
+++ b/src/events/close.c
@@ -28,6 +28,8 @@ void	free_loaded_textures(t_app *app)
 {
 	int	i;
 
+	if (!app || !app->mlx.ptr)
+		return ;
 	i = 0;
 	while (i < 4)
 	{
@@ -35,6 +37,12 @@ void	free_loaded_textures(t_app *app)
 		{
 			mlx_destroy_image(app->mlx.ptr, app->wall_text[i].ptr);
 			app->wall_text[i].ptr = NULL;
+			app->wall_text[i].addr = NULL;
+			app->wall_text[i].w = 0;
+			app->wall_text[i].h = 0;
+			app->wall_text[i].bpp = 0;
+			app->wall_text[i].line_len = 0;
+			app->wall_text[i].endian = 0;
 		}
 		i++;
 	}

--- a/src/events/close.c
+++ b/src/events/close.c
@@ -36,13 +36,7 @@ void	free_loaded_textures(t_app *app)
 		if (app->wall_text[i].ptr)
 		{
 			mlx_destroy_image(app->mlx.ptr, app->wall_text[i].ptr);
-			app->wall_text[i].ptr = NULL;
-			app->wall_text[i].addr = NULL;
-			app->wall_text[i].w = 0;
-			app->wall_text[i].h = 0;
-			app->wall_text[i].bpp = 0;
-			app->wall_text[i].line_len = 0;
-			app->wall_text[i].endian = 0;
+			ft_bzero(&app->wall_text[i], sizeof(t_img));
 		}
 		i++;
 	}

--- a/src/events/close.c
+++ b/src/events/close.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   close.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dajesus- <dajesus-@student.42.fr>          +#+  +:+       +#+        */
+/*   By: vinda-si <vinda-si@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/25 22:20:24 by dajesus-          #+#    #+#             */
-/*   Updated: 2026/03/06 01:53:20 by dajesus-         ###   ########.fr       */
+/*   Updated: 2026/03/11 23:16:51 by vinda-si         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,4 +22,20 @@ int	on_destroy(void *param)
 	app->running = 0;
 	mlx_loop_end(app->mlx.ptr);
 	return (0);
+}
+
+void	free_loaded_textures(t_app *app)
+{
+	int	i;
+
+	i = 0;
+	while (i < 4)
+	{
+		if (app->wall_text[i].ptr)
+		{
+			mlx_destroy_image(app->mlx.ptr, app->wall_text[i].ptr);
+			app->wall_text[i].ptr = NULL;
+		}
+		i++;
+	}
 }

--- a/src/init/textures_load.c
+++ b/src/init/textures_load.c
@@ -1,0 +1,38 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   textures_load.c                                    :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: vinda-si <vinda-si@student.42sp.org.br>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/03/11 22:58:45 by vinda-si          #+#    #+#             */
+/*   Updated: 2026/03/11 23:09:23 by vinda-si         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "cub3d.h"
+
+static int	load_single_texture(t_app *app, t_img *img, char *path)
+{
+	img->ptr = mlx_xpm_file_to_image(app->mlx.ptr, path, &img->w, &img->h);
+	if (!img->ptr)
+		return (ft_print_error("Failed to load XPM texture"));
+	img->addr = mlx_get_data_addr(img->ptr, &img->bpp,
+			&img->line_len, &img->endian);
+	if (!img->addr)
+		return (ft_print_error("Failed to get texture data address"));
+	return (0);
+}
+
+int	init_loaded_textures(t_app *app)
+{
+	if (load_single_texture(app, &app->wall_text[0], app->tex.no) != 0)
+		return (1);
+	if (load_single_texture(app, &app->wall_text[1], app->tex.so) != 0)
+		return (1);
+	if (load_single_texture(app, &app->wall_text[2], app->tex.we) != 0)
+		return (1);
+	if (load_single_texture(app, &app->wall_text[3], app->tex.ea) != 0)
+		return (1);
+	return (0);
+}

--- a/src/init/textures_load.c
+++ b/src/init/textures_load.c
@@ -38,18 +38,31 @@ static int	load_single_texture(t_app *app, t_img *img, char *path)
 	return (0);
 }
 
+static char	*get_tex_path(t_app *app, int index)
+{
+	if (index == TEX_NO)
+		return (app->tex.no);
+	if (index == TEX_SO)
+		return (app->tex.so);
+	if (index == TEX_WE)
+		return (app->tex.we);
+	return (app->tex.ea);
+}
+
 int	init_loaded_textures(t_app *app)
 {
+	int	i;
+
 	if (!app)
 		return (1);
 	ft_bzero(app->wall_text, sizeof(app->wall_text));
-	if (load_single_texture(app, &app->wall_text[TEX_NO], app->tex.no) != 0)
-		return (free_loaded_textures(app), 1);
-	if (load_single_texture(app, &app->wall_text[TEX_SO], app->tex.so) != 0)
-		return (free_loaded_textures(app), 1);
-	if (load_single_texture(app, &app->wall_text[TEX_WE], app->tex.we) != 0)
-		return (free_loaded_textures(app), 1);
-	if (load_single_texture(app, &app->wall_text[TEX_EA], app->tex.ea) != 0)
-		return (free_loaded_textures(app), 1);
+	i = 0;
+	while (i < NUM_WALL_TEX)
+	{
+		if (load_single_texture(app, &app->wall_text[i],
+				get_tex_path(app, i)) != 0)
+			return (free_loaded_textures(app), 1);
+		i++;
+	}
 	return (0);
 }

--- a/src/init/textures_load.c
+++ b/src/init/textures_load.c
@@ -43,13 +43,13 @@ int	init_loaded_textures(t_app *app)
 	if (!app)
 		return (1);
 	ft_bzero(app->wall_text, sizeof(app->wall_text));
-	if (load_single_texture(app, &app->wall_text[0], app->tex.no) != 0)
+	if (load_single_texture(app, &app->wall_text[TEX_NO], app->tex.no) != 0)
 		return (free_loaded_textures(app), 1);
-	if (load_single_texture(app, &app->wall_text[1], app->tex.so) != 0)
+	if (load_single_texture(app, &app->wall_text[TEX_SO], app->tex.so) != 0)
 		return (free_loaded_textures(app), 1);
-	if (load_single_texture(app, &app->wall_text[2], app->tex.we) != 0)
+	if (load_single_texture(app, &app->wall_text[TEX_WE], app->tex.we) != 0)
 		return (free_loaded_textures(app), 1);
-	if (load_single_texture(app, &app->wall_text[3], app->tex.ea) != 0)
+	if (load_single_texture(app, &app->wall_text[TEX_EA], app->tex.ea) != 0)
 		return (free_loaded_textures(app), 1);
 	return (0);
 }

--- a/src/init/textures_load.c
+++ b/src/init/textures_load.c
@@ -12,27 +12,44 @@
 
 #include "cub3d.h"
 
+static void	clear_img(t_img *img)
+{
+	if (!img)
+		return ;
+	ft_bzero(img, sizeof(*img));
+}
+
 static int	load_single_texture(t_app *app, t_img *img, char *path)
 {
+	if (!app || !app->mlx.ptr || !img || !path || *path == '\0')
+		return (ft_print_error("Failed to load XPM texture"));
+	clear_img(img);
 	img->ptr = mlx_xpm_file_to_image(app->mlx.ptr, path, &img->w, &img->h);
 	if (!img->ptr)
 		return (ft_print_error("Failed to load XPM texture"));
 	img->addr = mlx_get_data_addr(img->ptr, &img->bpp,
 			&img->line_len, &img->endian);
 	if (!img->addr)
+	{
+		mlx_destroy_image(app->mlx.ptr, img->ptr);
+		clear_img(img);
 		return (ft_print_error("Failed to get texture data address"));
+	}
 	return (0);
 }
 
 int	init_loaded_textures(t_app *app)
 {
+	if (!app)
+		return (1);
+	ft_bzero(app->wall_text, sizeof(app->wall_text));
 	if (load_single_texture(app, &app->wall_text[0], app->tex.no) != 0)
-		return (1);
+		return (free_loaded_textures(app), 1);
 	if (load_single_texture(app, &app->wall_text[1], app->tex.so) != 0)
-		return (1);
+		return (free_loaded_textures(app), 1);
 	if (load_single_texture(app, &app->wall_text[2], app->tex.we) != 0)
-		return (1);
+		return (free_loaded_textures(app), 1);
 	if (load_single_texture(app, &app->wall_text[3], app->tex.ea) != 0)
-		return (1);
+		return (free_loaded_textures(app), 1);
 	return (0);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dajesus- <dajesus-@student.42.fr>          +#+  +:+       +#+        */
+/*   By: vinda-si <vinda-si@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/25 21:02:28 by dajesus-          #+#    #+#             */
-/*   Updated: 2026/03/04 21:46:25 by dajesus-         ###   ########.fr       */
+/*   Updated: 2026/03/11 23:24:35 by vinda-si         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,6 +17,7 @@ static void	app_destroy(t_app *app)
 	if (!app)
 		return ;
 	framebuffer_destroy(app);
+	free_loaded_textures(app);
 	if (app->mlx.ptr && app->mlx.win)
 		mlx_destroy_window(app->mlx.ptr, app->mlx.win);
 	if (app->mlx.ptr)
@@ -38,6 +39,8 @@ static int	app_init(t_app *app)
 	if (!app->mlx.win)
 		return (0);
 	if (!framebuffer_init(app))
+		return (0);
+	if (init_loaded_textures(app) != 0)
 		return (0);
 	return (1);
 }


### PR DESCRIPTION
Objetivo:

Implementar o carregamento dos arquivos .xpm validados, pensando no raycaster.

O que fiz:

- Adicionei o array wall_text[4] na estrutura t_app (structs.h) para armazenar as texturas (Norte, Sul, Oeste, Leste);
- Criei o arquivo src/init/textures_load.c para converter os caminhos das texturas em dados de imagemvia função mlx_xpm_file_to_image;
- Implementei a função free_loaded_textures em src/events/close.c para destruir as imagens criadas, evitando leaks;
- Integrei as chamadas de carregamento e destruição no ciclo de vida principal em src/main.c (app_init e app_destroy);
- Atualizei o Makefile e as declarações no cabeçalho cub3d.h;