### PR TITLE
fix: reject oversized RGB values before integer wraparound

### DIFF
--- a/maps/invalid/color_overflow_rgb.cub
+++ b/maps/invalid/color_overflow_rgb.cub
@@ -1,0 +1,21 @@
+NO ./assets/textures/north.xpm
+SO ./assets/textures/south.xpm
+WE ./assets/textures/west.xpm
+EA ./assets/textures/east.xpm
+
+F 4294967551,0,0
+C 200,200,200
+
+11111
+10001
+10S01
+10001
+10001
+10001
+11001
+10001
+10001
+10001
+10001
+10001
+11111

--- a/src/parsing/colors_utils.c
+++ b/src/parsing/colors_utils.c
@@ -29,11 +29,19 @@ void	free_split(char **parts)
 
 int	is_valid_component(char *s)
 {
+	int	len;
+
 	s = ft_skip_spaces(s);
 	if (*s == '\0')
 		return (0);
+	len = 0;
 	while (ft_isdigit(*s))
+	{
+		len++;
 		s++;
+	}
+	if (len > 3)
+		return (0);
 	s = ft_skip_spaces(s);
 	return (*s == '\0');
 }

--- a/tests/integration/parsing/test_parsing_integration.c
+++ b/tests/integration/parsing/test_parsing_integration.c
@@ -144,6 +144,19 @@ Test(parse_colors, rejects_invalid_rgb_value)
 	free_all(&file, &app);
 }
 
+Test(parse_colors, rejects_overflowed_rgb_value)
+{
+	t_file	file;
+	t_app	app;
+
+	ft_bzero(&app, sizeof(app));
+	cr_assert(parse_cub_file(2, (char *[]) {"./cub3D",
+		"maps/invalid/color_overflow_rgb.cub", NULL}, &file) == 0);
+	cr_assert(parse_textures(&app, &file) == 0);
+	cr_assert(parse_colors(&app, &file) != 0);
+	free_all(&file, &app);
+}
+
 Test(parse_colors, rejects_identifier_without_space)
 {
 	t_file	file;


### PR DESCRIPTION
## Summary

- Add digit-length check in `is_valid_component` to reject RGB components with more than 3 digits, preventing `ft_atoi` integer overflow from wrapping large values (e.g. `4294967551`) into the valid `[0, 255]` range.
- Add test fixture (`maps/invalid/color_overflow_rgb.cub`) and integration test (`rejects_overflowed_rgb_value`).

Closes #36