### PR TITLE
feat: add FPS counter with frame time display

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ SRCS		= $(SRC_DIR)/main.c \
 			  $(SRC_DIR)/init/framebuffer.c \
 			  $(SRC_DIR)/init/textures_load.c \
 			  $(SRC_DIR)/render/render.c \
+			  $(SRC_DIR)/render/fps.c \
 			  $(SRC_DIR)/render/wall_slices.c \
 			  $(SRC_DIR)/raycasting/raycast_core.c \
 			  $(SRC_DIR)/raycasting/raycast_init.c \

--- a/include/cub3d.h
+++ b/include/cub3d.h
@@ -38,6 +38,8 @@ int		framebuffer_init(t_app *app);
 void	framebuffer_destroy(t_app *app);
 int		render_frame(t_app *app);
 void	render_walls(t_app *app);
+void	fps_update(t_app *app);
+void	fps_draw(t_app *app);
 int		init_loaded_textures(t_app *app);
 void	free_loaded_textures(t_app *app);
 

--- a/include/player.h
+++ b/include/player.h
@@ -30,6 +30,7 @@
 # define PLAYER_TERM_DEBUG 1
 # define FPS_DISPLAY 1
 # define FPS_SMOOTHING 0.9
+# define FPS_UPDATE_US 500000L
 
 # define TERM_RESET "\033[0m"
 # define TERM_WALL "\033[44m"

--- a/include/player.h
+++ b/include/player.h
@@ -29,7 +29,6 @@
 
 # define PLAYER_TERM_DEBUG 1
 # define FPS_DISPLAY 1
-# define FPS_SMOOTHING 0.9
 # define FPS_UPDATE_US 500000L
 
 # define TERM_RESET "\033[0m"

--- a/include/player.h
+++ b/include/player.h
@@ -28,6 +28,8 @@
 # define USEC_PER_SEC_DBL 1000000.0
 
 # define PLAYER_TERM_DEBUG 1
+# define FPS_DISPLAY 1
+# define FPS_SMOOTHING 0.9
 
 # define TERM_RESET "\033[0m"
 # define TERM_WALL "\033[44m"

--- a/include/structs.h
+++ b/include/structs.h
@@ -135,7 +135,7 @@ typedef struct s_app
 	long			last_frame_us;
 	int				fps_frames;
 	int				fps_display;
-	int				ft_ms_display;
+	int				frametime_ms;
 	long			fps_update_us;
 }					t_app;
 

--- a/include/structs.h
+++ b/include/structs.h
@@ -133,6 +133,7 @@ typedef struct s_app
 	t_player		player;
 	t_input			input;
 	long			last_frame_us;
+	double			fps;
 }					t_app;
 
 typedef struct s_term_ctx

--- a/include/structs.h
+++ b/include/structs.h
@@ -133,7 +133,7 @@ typedef struct s_app
 	t_player		player;
 	t_input			input;
 	long			last_frame_us;
-	double			fps;
+	int				fps_frames;
 	int				fps_display;
 	long			fps_update_us;
 }					t_app;

--- a/include/structs.h
+++ b/include/structs.h
@@ -134,6 +134,8 @@ typedef struct s_app
 	t_input			input;
 	long			last_frame_us;
 	double			fps;
+	int				fps_display;
+	long			fps_update_us;
 }					t_app;
 
 typedef struct s_term_ctx

--- a/include/structs.h
+++ b/include/structs.h
@@ -135,6 +135,7 @@ typedef struct s_app
 	long			last_frame_us;
 	int				fps_frames;
 	int				fps_display;
+	int				ft_ms_display;
 	long			fps_update_us;
 }					t_app;
 

--- a/src/player/movement.c
+++ b/src/player/movement.c
@@ -84,8 +84,15 @@ void	player_update(t_app *app)
 		return ;
 	dt = frame_dt(app);
 	if (dt > 0.0 && FPS_DISPLAY)
+	{
 		app->fps = FPS_SMOOTHING * app->fps
 			+ (1.0 - FPS_SMOOTHING) * (1.0 / dt);
+		if (app->last_frame_us - app->fps_update_us >= FPS_UPDATE_US)
+		{
+			app->fps_display = (int)app->fps;
+			app->fps_update_us = app->last_frame_us;
+		}
+	}
 	if (dt > PLAYER_MAX_DT)
 		dt = PLAYER_MAX_DT;
 	if (dt <= 0.0)

--- a/src/player/movement.c
+++ b/src/player/movement.c
@@ -29,8 +29,6 @@ static double	frame_dt(t_app *app)
 	app->last_frame_us = now;
 	if (dt < 0.0)
 		return (0.0);
-	if (dt > PLAYER_MAX_DT)
-		return (PLAYER_MAX_DT);
 	return (dt);
 }
 
@@ -85,6 +83,11 @@ void	player_update(t_app *app)
 	if (!app)
 		return ;
 	dt = frame_dt(app);
+	if (dt > 0.0 && FPS_DISPLAY)
+		app->fps = FPS_SMOOTHING * app->fps
+			+ (1.0 - FPS_SMOOTHING) * (1.0 / dt);
+	if (dt > PLAYER_MAX_DT)
+		dt = PLAYER_MAX_DT;
 	if (dt <= 0.0)
 		return ;
 	player_rotate_update(app, dt);

--- a/src/player/movement.c
+++ b/src/player/movement.c
@@ -84,16 +84,7 @@ void	player_update(t_app *app)
 		return ;
 	dt = frame_dt(app);
 	if (FPS_DISPLAY)
-	{
-		app->fps_frames++;
-		if (app->last_frame_us - app->fps_update_us >= FPS_UPDATE_US)
-		{
-			app->fps_display = app->fps_frames * (int)(USEC_PER_SEC
-					/ FPS_UPDATE_US);
-			app->fps_frames = 0;
-			app->fps_update_us = app->last_frame_us;
-		}
-	}
+		fps_update(app);
 	if (dt > PLAYER_MAX_DT)
 		dt = PLAYER_MAX_DT;
 	if (dt <= 0.0)

--- a/src/player/movement.c
+++ b/src/player/movement.c
@@ -83,13 +83,14 @@ void	player_update(t_app *app)
 	if (!app)
 		return ;
 	dt = frame_dt(app);
-	if (dt > 0.0 && FPS_DISPLAY)
+	if (FPS_DISPLAY)
 	{
-		app->fps = FPS_SMOOTHING * app->fps
-			+ (1.0 - FPS_SMOOTHING) * (1.0 / dt);
+		app->fps_frames++;
 		if (app->last_frame_us - app->fps_update_us >= FPS_UPDATE_US)
 		{
-			app->fps_display = (int)app->fps;
+			app->fps_display = app->fps_frames * (int)(USEC_PER_SEC
+					/ FPS_UPDATE_US);
+			app->fps_frames = 0;
 			app->fps_update_us = app->last_frame_us;
 		}
 	}

--- a/src/render/fps.c
+++ b/src/render/fps.c
@@ -1,0 +1,51 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   fps.c                                              :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: alexanfe <alexanfe@student.42sp.org.br>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/03/12 22:29:02 by alexanfe          #+#    #+#             */
+/*   Updated: 2026/03/12 22:29:27 by alexanfe         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "cub3d.h"
+
+static void	draw_overlay_str(t_app *app, char *prefix, int value, int y)
+{
+	char	*num;
+	char	*str;
+
+	num = ft_itoa(value);
+	if (!num)
+		return ;
+	str = ft_strjoin(prefix, num);
+	free(num);
+	if (!str)
+		return ;
+	mlx_string_put(app->mlx.ptr, app->mlx.win, 10, y, 0x000000, str);
+	free(str);
+}
+
+void	fps_draw(t_app *app)
+{
+	draw_overlay_str(app, "FPS: ", app->fps_display, 20);
+	draw_overlay_str(app, "MS:  ", app->ft_ms_display, 40);
+}
+
+void	fps_update(t_app *app)
+{
+	long	elapsed;
+
+	app->fps_frames++;
+	elapsed = app->last_frame_us - app->fps_update_us;
+	if (elapsed < FPS_UPDATE_US)
+		return ;
+	app->fps_display = (int)(app->fps_frames
+			* USEC_PER_SEC_DBL / elapsed);
+	app->ft_ms_display = (int)(elapsed
+			/ (app->fps_frames * 1000.0) + 0.5);
+	app->fps_frames = 0;
+	app->fps_update_us = app->last_frame_us;
+}

--- a/src/render/render.c
+++ b/src/render/render.c
@@ -54,22 +54,6 @@ static void	draw_background(t_app *app)
 	fill_background_half(&app->frame, app->frame.h / 2, app->frame.h, f_color);
 }
 
-static void	draw_fps(t_app *app)
-{
-	char	*num;
-	char	*str;
-
-	num = ft_itoa(app->fps_display);
-	if (!num)
-		return ;
-	str = ft_strjoin("FPS: ", num);
-	free(num);
-	if (!str)
-		return ;
-	mlx_string_put(app->mlx.ptr, app->mlx.win, 10, 20, 0x000000, str);
-	free(str);
-}
-
 int	render_frame(t_app *app)
 {
 	if (!app || !app->mlx.ptr)
@@ -81,6 +65,6 @@ int	render_frame(t_app *app)
 	render_walls(app);
 	mlx_put_image_to_window(app->mlx.ptr, app->mlx.win, app->frame.ptr, 0, 0);
 	if (FPS_DISPLAY)
-		draw_fps(app);
+		fps_draw(app);
 	return (0);
 }

--- a/src/render/render.c
+++ b/src/render/render.c
@@ -54,6 +54,22 @@ static void	draw_background(t_app *app)
 	fill_background_half(&app->frame, app->frame.h / 2, app->frame.h, f_color);
 }
 
+static void	draw_fps(t_app *app)
+{
+	char	*num;
+	char	*str;
+
+	num = ft_itoa((int)app->fps);
+	if (!num)
+		return ;
+	str = ft_strjoin("FPS: ", num);
+	free(num);
+	if (!str)
+		return ;
+	mlx_string_put(app->mlx.ptr, app->mlx.win, 10, 20, 0xFFFFFF, str);
+	free(str);
+}
+
 int	render_frame(t_app *app)
 {
 	if (!app || !app->mlx.ptr)
@@ -64,5 +80,7 @@ int	render_frame(t_app *app)
 	draw_background(app);
 	render_walls(app);
 	mlx_put_image_to_window(app->mlx.ptr, app->mlx.win, app->frame.ptr, 0, 0);
+	if (FPS_DISPLAY)
+		draw_fps(app);
 	return (0);
 }

--- a/src/render/render.c
+++ b/src/render/render.c
@@ -59,14 +59,14 @@ static void	draw_fps(t_app *app)
 	char	*num;
 	char	*str;
 
-	num = ft_itoa((int)app->fps);
+	num = ft_itoa(app->fps_display);
 	if (!num)
 		return ;
 	str = ft_strjoin("FPS: ", num);
 	free(num);
 	if (!str)
 		return ;
-	mlx_string_put(app->mlx.ptr, app->mlx.win, 10, 20, 0xFFFFFF, str);
+	mlx_string_put(app->mlx.ptr, app->mlx.win, 10, 20, 0x000000, str);
 	free(str);
 }
 


### PR DESCRIPTION
## Summary

- Add an on-screen FPS counter and frame time (ms) overlay using `mlx_string_put`, toggled via the `FPS_DISPLAY` compile-time flag
- FPS is computed using frame-counting over a 500ms window with actual elapsed time for accuracy
- Frame time display (MS) helps diagnose whether FPS variance reflects real performance issues or just the nonlinear FPS scale

## Changes

| File | Description |
|---|---|
| `include/structs.h` | Added `fps_frames`, `fps_display`, `ft_ms_display`, `fps_update_us` fields to `t_app` |
| `include/player.h` | Added `FPS_DISPLAY` and `FPS_UPDATE_US` constants |
| `include/cub3d.h` | Added `fps_update` and `fps_draw` prototypes |
| `src/render/fps.c` | New file: FPS counting logic (`fps_update`) and overlay rendering (`fps_draw`) |
| `src/render/render.c` | Calls `fps_draw` after image blit when `FPS_DISPLAY` is enabled |
| `src/player/movement.c` | Removed dt clamping from `frame_dt()`, calls `fps_update` from `player_update()` |
| `Makefile` | Added `fps.c` to build sources |

## Notes

- All allocations from `ft_itoa`/`ft_strjoin` are freed within `draw_overlay_str` each frame
- Norminette passes on all modified files
- Set `FPS_DISPLAY` to `0` in `include/player.h` and recompile to disable