### PR TITLE
refactor: deduplicate map cell bounds-check into shared map_cell_at

### DIFF
--- a/include/parsing.h
+++ b/include/parsing.h
@@ -35,5 +35,6 @@ int		validate_player_spawn(t_app *app, t_file *file);
 int		find_map_range(t_file *file, int *out_start, int *out_end);
 int		dup_map_block(t_file *file, int start, int end);
 int		is_valid_component(char *s);
+int		map_cell_at(t_file *file, int x, int y);
 
 #endif

--- a/src/parsing/map_closed_utils.c
+++ b/src/parsing/map_closed_utils.c
@@ -12,16 +12,6 @@
 
 #include "cub3d.h"
 
-static int	line_width(const char *s)
-{
-	int	w;
-
-	w = 0;
-	while (s[w])
-		w++;
-	return (w);
-}
-
 static void	free_clone(char **clone, int used)
 {
 	int	i;
@@ -59,28 +49,31 @@ char	**map_clone(t_file *file)
 
 int	map_cell(char **map, int y, int x)
 {
-	int	w;
-
 	if (y < 0 || x < 0)
 		return (0);
 	if (!map[y])
 		return (0);
-	w = line_width(map[y]);
-	if (x >= w)
+	if (x >= (int)ft_strlen(map[y]))
 		return (0);
 	return (map[y][x]);
 }
 
 void	map_mark(char **map, int y, int x, char v)
 {
-	int	w;
-
 	if (y < 0 || x < 0)
 		return ;
 	if (!map[y])
 		return ;
-	w = line_width(map[y]);
-	if (x >= w)
+	if (x >= (int)ft_strlen(map[y]))
 		return ;
 	map[y][x] = v;
+}
+
+int	map_cell_at(t_file *file, int x, int y)
+{
+	if (!file || !file->map)
+		return (0);
+	if (y >= file->map_height)
+		return (0);
+	return (map_cell(file->map, y, x));
 }

--- a/src/player/movement_collision.c
+++ b/src/player/movement_collision.c
@@ -12,40 +12,20 @@
 
 #include "cub3d.h"
 
-static int	map_cell(t_file *file, int x, int y)
-{
-	int		w;
-	char	*row;
-
-	if (!file || !file->map)
-		return (0);
-	if (x < 0 || y < 0 || y >= file->map_height)
-		return (0);
-	row = file->map[y];
-	if (!row)
-		return (0);
-	w = 0;
-	while (row[w])
-		w++;
-	if (x >= w)
-		return (0);
-	return (row[x]);
-}
-
 static int	is_blocked(t_app *app, double x, double y)
 {
 	if (!app || !app->file)
 		return (1);
-	if (map_cell(app->file, (int)(x - PLAYER_COLLISION_RADIUS),
+	if (map_cell_at(app->file, (int)(x - PLAYER_COLLISION_RADIUS),
 		(int)(y - PLAYER_COLLISION_RADIUS)) != '0')
 		return (1);
-	if (map_cell(app->file, (int)(x + PLAYER_COLLISION_RADIUS),
+	if (map_cell_at(app->file, (int)(x + PLAYER_COLLISION_RADIUS),
 		(int)(y - PLAYER_COLLISION_RADIUS)) != '0')
 		return (1);
-	if (map_cell(app->file, (int)(x - PLAYER_COLLISION_RADIUS),
+	if (map_cell_at(app->file, (int)(x - PLAYER_COLLISION_RADIUS),
 		(int)(y + PLAYER_COLLISION_RADIUS)) != '0')
 		return (1);
-	if (map_cell(app->file, (int)(x + PLAYER_COLLISION_RADIUS),
+	if (map_cell_at(app->file, (int)(x + PLAYER_COLLISION_RADIUS),
 		(int)(y + PLAYER_COLLISION_RADIUS)) != '0')
 		return (1);
 	return (0);

--- a/src/raycasting/raycast_dda.c
+++ b/src/raycasting/raycast_dda.c
@@ -12,20 +12,6 @@
 
 #include "cub3d.h"
 
-static int	is_wall_cell(t_file *file, int x, int y)
-{
-	int	len;
-
-	if (!file || !file->map)
-		return (1);
-	if (x < 0 || y < 0 || y >= file->map_height)
-		return (1);
-	len = (int)ft_strlen(file->map[y]);
-	if (x >= len)
-		return (1);
-	return (file->map[y][x] == '1');
-}
-
 static void	do_step(t_ray *ray)
 {
 	if (ray->side_dist_x < ray->side_dist_y)
@@ -49,6 +35,6 @@ void	ray_dda(t_app *app, t_ray *ray)
 	while (!ray->hit)
 	{
 		do_step(ray);
-		ray->hit = is_wall_cell(app->file, ray->map_x, ray->map_y);
+		ray->hit = (map_cell_at(app->file, ray->map_x, ray->map_y) != '0');
 	}
 }


### PR DESCRIPTION
## Summary

Consolidates three duplicate implementations of bounds-checked map cell lookup (~45 lines total) into a single shared `map_cell_at()` function.

## What changed

Three separate functions performed the same logic — validate map coordinates, check bounds, return the character at that position:

| File | Function | Status |
|---|---|---|
| `src/parsing/map_closed_utils.c` | `map_cell(char **map, int y, int x)` | **Kept** (used by flood fill on cloned `char **`) |
| `src/player/movement_collision.c` | `static map_cell(t_file*, int x, int y)` | **Removed** (19 lines) |
| `src/raycasting/raycast_dda.c` | `static is_wall_cell(t_file*, int x, int y)` | **Removed** (13 lines) |

A new shared function `map_cell_at(t_file *file, int x, int y)` was added, which delegates to the existing `map_cell(char **, int y, int x)` after validating the `t_file *` pointer and height bounds.

## Why

- **Code duplication**: three implementations of the same bounds-check logic, with inconsistent parameter ordering (`y,x` vs `x,y`) and subtle semantic differences (one returned char values, another returned a wall boolean).
- **Maintenance risk**: a bug fix or behavior change would need to be applied in three places.
- **Consistency**: `map_cell_at` uses a single `(x, y)` parameter convention, resolving the mixed ordering.

## How

1. Removed `line_width()` from `map_closed_utils.c` (a duplicate of `ft_strlen`) to free a function slot within the 42 norminette 5-function-per-file limit.
2. Added `map_cell_at(t_file *file, int x, int y)` in `map_closed_utils.c`, delegating to the existing `map_cell()`.
3. Declared `map_cell_at` in `include/parsing.h`.
4. Replaced the static `map_cell` in `movement_collision.c` with calls to `map_cell_at`.
5. Replaced the static `is_wall_cell` in `raycast_dda.c` with `map_cell_at(...) != '0'` — preserving identical behavior (OOB and walls both stop the ray).

## Files touched

- `include/parsing.h` — added `map_cell_at` declaration
- `src/parsing/map_closed_utils.c` — removed `line_width`, replaced with `ft_strlen`; added `map_cell_at`
- `src/player/movement_collision.c` — removed 19-line static `map_cell`, uses `map_cell_at`
- `src/raycasting/raycast_dda.c` — removed 13-line static `is_wall_cell`, uses `map_cell_at`

**Net change: +17 / -57 lines**