### PR TITLE
Perf: optimize raycasting hot path

### DIFF
--- a/include/render.h
+++ b/include/render.h
@@ -23,6 +23,7 @@ void	player_update(t_app *app);
 void	rotate_player(t_player *p, double angle);
 
 void	ray_init(t_app *app, int screen_x, t_ray *ray);
+void	ray_init_from_core(t_app *app, t_ray *ray, t_raycore *core);
 void	render_walls(t_app *app);
 void	raycore_init(t_app *app, int screen_x, t_raycore *out);
 void	ray_dda(t_app *app, t_ray *ray);

--- a/include/structs.h
+++ b/include/structs.h
@@ -127,6 +127,7 @@ typedef struct s_app
 {
 	t_mlx			mlx;
 	t_img			frame;
+	double			ray_camera_step;
 	t_img			wall_text[NUM_WALL_TEX];
 	t_file			*file;
 	t_player		player;

--- a/src/init/framebuffer.c
+++ b/src/init/framebuffer.c
@@ -18,6 +18,7 @@ int	framebuffer_init(t_app *app)
 		return (0);
 	app->frame.w = CUB3D_WIN_W;
 	app->frame.h = CUB3D_WIN_H;
+	app->ray_camera_step = RAYCORE_CAM_SCALE / (double)app->frame.w;
 	app->frame.ptr = mlx_new_image(app->mlx.ptr, app->frame.w, app->frame.h);
 	if (!app->frame.ptr)
 		return (0);

--- a/src/player/rotate.c
+++ b/src/player/rotate.c
@@ -16,13 +16,17 @@ void	rotate_player(t_player *p, double angle)
 {
 	double	old_dir_x;
 	double	old_plane_x;
+	double	s;
+	double	c;
 
+	s = sin(angle);
+	c = cos(angle);
 	old_dir_x = p->dir_x;
-	p->dir_x = p->dir_x * cos(angle) - p->dir_y * sin(angle);
-	p->dir_y = old_dir_x * sin(angle) + p->dir_y * cos(angle);
+	p->dir_x = p->dir_x * c - p->dir_y * s;
+	p->dir_y = old_dir_x * s + p->dir_y * c;
 	old_plane_x = p->plane_x;
-	p->plane_x = p->plane_x * cos(angle) - p->plane_y * sin(angle);
-	p->plane_y = old_plane_x * sin(angle) + p->plane_y * cos(angle);
+	p->plane_x = p->plane_x * c - p->plane_y * s;
+	p->plane_y = old_plane_x * s + p->plane_y * c;
 }
 
 void	player_rotate_update(t_app *app, double dt)

--- a/src/raycasting/raycast_core.c
+++ b/src/raycasting/raycast_core.c
@@ -21,8 +21,7 @@ void	raycore_init(t_app *app, int screen_x, t_raycore *out)
 	ft_bzero(out, sizeof(*out));
 	if (!app || app->frame.w <= 0)
 		return ;
-	cam_x = (RAYCORE_CAM_SCALE * (double)screen_x) / (double)app->frame.w
-		- RAYCORE_CAM_SHIFT;
+	cam_x = (app->ray_camera_step * (double)screen_x) - RAYCORE_CAM_SHIFT;
 	out->camera_x = cam_x;
 	out->ray_dir_x = app->player.dir_x + app->player.plane_x * cam_x;
 	out->ray_dir_y = app->player.dir_y + app->player.plane_y * cam_x;

--- a/src/raycasting/raycast_dda.c
+++ b/src/raycasting/raycast_dda.c
@@ -14,18 +14,14 @@
 
 static void	do_step(t_ray *ray)
 {
-	if (ray->side_dist_x < ray->side_dist_y)
-	{
-		ray->side_dist_x += ray->delta_dist_x;
-		ray->map_x += ray->step_x;
-		ray->side = 0;
-	}
-	else
-	{
-		ray->side_dist_y += ray->delta_dist_y;
-		ray->map_y += ray->step_y;
-		ray->side = 1;
-	}
+	int	step_in_x;
+
+	step_in_x = (ray->side_dist_x < ray->side_dist_y);
+	ray->side_dist_x += ray->delta_dist_x * step_in_x;
+	ray->map_x += ray->step_x * step_in_x;
+	ray->side_dist_y += ray->delta_dist_y * (1 - step_in_x);
+	ray->map_y += ray->step_y * (1 - step_in_x);
+	ray->side = (step_in_x == 0);
 }
 
 void	ray_dda(t_app *app, t_ray *ray)

--- a/src/raycasting/raycast_init.c
+++ b/src/raycasting/raycast_init.c
@@ -24,14 +24,26 @@ static void	ray_calc_dir(t_app *app, int screen_x, t_ray *ray)
 
 static void	ray_calc_delta(t_player *p, t_ray *ray)
 {
+	double	inv;
+
 	ray->map_x = (int)p->x;
 	ray->map_y = (int)p->y;
 	ray->delta_dist_x = RAY_HUGE;
 	ray->delta_dist_y = RAY_HUGE;
 	if (ray->dir_x != 0.0)
-		ray->delta_dist_x = fabs(1.0 / ray->dir_x);
+	{
+		inv = 1.0 / ray->dir_x;
+		if (inv < 0.0)
+			inv = -inv;
+		ray->delta_dist_x = inv;
+	}
 	if (ray->dir_y != 0.0)
-		ray->delta_dist_y = fabs(1.0 / ray->dir_y);
+	{
+		inv = 1.0 / ray->dir_y;
+		if (inv < 0.0)
+			inv = -inv;
+		ray->delta_dist_y = inv;
+	}
 }
 
 static void	ray_calc_step_side(t_player *p, t_ray *ray)
@@ -71,6 +83,24 @@ void	ray_init(t_app *app, int screen_x, t_ray *ray)
 		return ;
 	p = &app->player;
 	ray_calc_dir(app, screen_x, ray);
+	ray_calc_delta(p, ray);
+	ray_calc_step_side(p, ray);
+	ray->hit = 0;
+}
+
+void	ray_init_from_core(t_app *app, t_ray *ray, t_raycore *core)
+{
+	t_player	*p;
+
+	if (!ray)
+		return ;
+	ft_bzero(ray, sizeof(*ray));
+	if (!app || !core)
+		return ;
+	p = &app->player;
+	ray->camera_x = core->camera_x;
+	ray->dir_x = core->ray_dir_x;
+	ray->dir_y = core->ray_dir_y;
 	ray_calc_delta(p, ray);
 	ray_calc_step_side(p, ray);
 	ray->hit = 0;

--- a/src/render/wall_slices.c
+++ b/src/render/wall_slices.c
@@ -79,13 +79,14 @@ static void	draw_textured_column(t_img *img, t_tex_col *col,
 	}
 }
 
-static void	render_wall_column(t_app *app, t_img *img, int screen_x)
+static void	render_wall_column(t_app *app, t_img *img, int screen_x,
+				t_raycore *core)
 {
 	t_ray		ray;
 	t_tex_col	col;
 	double		perp_dist;
 
-	ray_init(app, screen_x, &ray);
+	ray_init_from_core(app, &ray, core);
 	ray_dda(app, &ray);
 	perp_dist = ray_perp_dist(app, &ray);
 	if (perp_dist < 0.0001)
@@ -104,18 +105,29 @@ static void	render_wall_column(t_app *app, t_img *img, int screen_x)
 
 void	render_walls(t_app *app)
 {
-	t_img	*img;
-	int		x;
+	t_img		*img;
+	t_raycore	core;
+	t_raycore	step;
+	double		cam_step;
+	int			x;
 
 	if (!app || !app->file)
 		return ;
 	img = &app->frame;
 	if (!img || !img->addr || img->w <= 0 || img->h <= 0)
 		return ;
-	x = 0;
-	while (x < img->w)
+	cam_step = app->ray_camera_step;
+	core.camera_x = -RAYCORE_CAM_SHIFT;
+	core.ray_dir_x = app->player.dir_x + app->player.plane_x * core.camera_x;
+	core.ray_dir_y = app->player.dir_y + app->player.plane_y * core.camera_x;
+	step.ray_dir_x = app->player.plane_x * cam_step;
+	step.ray_dir_y = app->player.plane_y * cam_step;
+	x = -1;
+	while (++x < img->w)
 	{
-		render_wall_column(app, img, x);
-		x++;
+		render_wall_column(app, img, x, &core);
+		core.camera_x += cam_step;
+		core.ray_dir_x += step.ray_dir_x;
+		core.ray_dir_y += step.ray_dir_y;
 	}
 }


### PR DESCRIPTION
## Summary

Optimizes the raycasting hot path by reducing expensive per-frame/per-column math and minimizing branching inside the DDA step, while keeping behavior unchanged and staying 42 Norm compliant.

## What changed

Focused performance improvements were applied in the core render loop and raycasting math:

| Optimization | Where | Notes |
|---|---|---|
| Cache `sin()` / `cos()` in rotation | rotate.c | Removes repeated trig calls per rotation update |
| Cache `camera_step` (`2.0 / width`) in `t_app` | structs.h, framebuffer.c | Computed once during framebuffer init |
| Remove per-column division for `camera_x` | raycast_core.c | `camera_x = (step * x) - 1.0` |
| Remove `fabs()` from `delta_dist_*` | raycast_init.c | Uses `inv = 1/dir; if (inv < 0) inv = -inv;` |
| Reduce branching in DDA step | raycast_dda.c | Uses a single compare + arithmetic updates |
| Incremental `camera_x` + `ray_dir` per column | wall_slices.c | Avoids repeated `plane * camera_x` multiplications |
| New initializer from precomputed raycore | render.h, raycast_init.c | Adds `ray_init_from_core()` |

## Why

- **Hot path cost**: raycasting runs once per screen column every frame; shaving even small operations (divisions, trig repeats, extra multiplications) has a large cumulative impact.
- **Lower branch pressure**: the DDA loop is extremely frequent; reducing branching improves predictability and throughput.
- **Keep architecture stable**: applies “safe” optimizations without a major refactor (no LUT tables, no float-wide rewrite, no `player.angle` re-architecture).

## How

1. Updated `rotate_player()` to compute `s = sin(angle)` and `c = cos(angle)` once and reuse them for both `dir` and `plane` rotation.
2. Added `ray_camera_step` to `t_app` and computed it once in `framebuffer_init()` as `RAYCORE_CAM_SCALE / frame.w`.
3. Changed `raycore_init()` to use cached `ray_camera_step` (removing per-column division).
4. Updated `ray_calc_delta()` to compute `delta_dist_*` via `inv = 1.0 / dir` and a simple sign fix (no `fabs()`).
5. Refactored the DDA `do_step()` to reduce branching by using a single comparison and arithmetic updates.
6. Implemented `ray_init_from_core()` to initialize a `t_ray` from a precomputed `t_raycore`.
7. Refactored wall rendering to increment `camera_x` and `ray_dir` per column (instead of recomputing with multiplications each time), while keeping Norm constraints.

## Files touched

- rotate.c — caches trig results for rotation
- structs.h — adds `ray_camera_step` to `t_app`
- framebuffer.c — computes `ray_camera_step` once at init
- raycast_core.c — uses cached step for `camera_x`
- raycast_init.c — removes `fabs()`; adds `ray_init_from_core()`
- raycast_dda.c — reduces branching in DDA step
- render.h — declares `ray_init_from_core()`
- wall_slices.c — incremental `camera_x` and `ray_dir` per column + uses `ray_init_from_core()`

**Net change: performance-focused refactor; no behavior change intended**

Closed by #58 . The performance hot path optimizations are now on the refactor/migrate-MLX42